### PR TITLE
cli/attach: don't crash on stdio termination

### DIFF
--- a/cli/src/commands/attach.rs
+++ b/cli/src/commands/attach.rs
@@ -317,7 +317,19 @@ const MONITOR_SNIPPET: &str = r##"defmodule OvcsAttachDiag do
   # On a Pi with a busy CAN bus a sync `File.write!` per message
   # serialises the bus/can loops and the SSH pane lags seconds behind
   # real time. Stick to `IO.puts` and rely on the TUI panes only.
-  def log(line), do: IO.puts(line)
+  #
+  # When the Rust attach harness tears down the remsh, `:standard_io`
+  # terminates and every subsequent `IO.puts` raises `:terminated` —
+  # which the BEAM's logger backend would then itself try to write
+  # via the same dead stdio, cascading into a noisy crash storm. The
+  # spawned monitor processes are orphans without supervisors, so the
+  # right answer when stdio is gone is to silently exit them; the
+  # next attach attempt spawns fresh ones.
+  def log(line) do
+    IO.puts(line)
+  rescue
+    ErlangError -> exit(:normal)
+  end
 end
 
 OvcsAttachDiag.log("OVCS_CAN\t[mon]\talive\tnode=#{inspect(node())}")


### PR DESCRIPTION
## Summary

The attach monitor snippet runs `IO.puts` directly. When the Rust harness disconnects the remsh, `:standard_io` terminates; every subsequent `IO.puts` raises `ErlangError: :terminated`; the BEAM's logger backend tries to format and write the crash through the same dead stdio, cascading into a noisy crash storm.

```
[error] Process #PID<0.1678.0> raised an exception
** (ErlangError) Erlang error: :terminated:
  * 1st argument: the device has terminated
    (stdlib 6.2) io.erl:198: :io.put_chars(:standard_io, [...])
    …
[error] GenServer #PID<0.1655.0> terminating
** (stop) :terminated
    (stdlib 6.2) io.erl:198: :io.put_chars(:standard_io, [...])
    (ring_logger 0.11.5) lib/ring_logger/client.ex:211: RingLogger.Client.handle_info/2
```

The candump / OvcsBus loops are bare `spawn`'d processes — no supervisor, no retry. The right answer when stdio dies is to exit them quietly. The next attach attempt spawns fresh ones against a working remsh.

## Test plan

- [x] Rebuilt the CLI via `mise run cli`.
- [ ] Manual: `./ovcs run ovcs_mini` → `./ovcs attach ovcs_mini` → quit the attach TUI. No crash spam should appear in the bridge BEAM's log.