### PR TITLE
ovcs_drivers: BNO085.Dummy → OvcsDrivers.Imu.Dummy

### DIFF
--- a/bridges/ros_bridge/lib/ros_bridge.ex
+++ b/bridges/ros_bridge/lib/ros_bridge.ex
@@ -19,7 +19,7 @@ defmodule RosBridge do
   supply per-deployment knobs (Zenoh broker IP, etc.).
 
   Host vs. target is handled at compile time: on host we wire
-  `BNO085.Dummy` instead of `BNO085.I2C` so the IMU publish path
+  `OvcsDrivers.Imu.Dummy` instead of `BNO085.I2C` so the IMU publish path
   still runs end-to-end against a local Zenoh router without
   hardware.
   """
@@ -44,7 +44,7 @@ defmodule RosBridge do
   # `children/0` clauses, exactly one of which is in the firmware.
   if Mix.target() == :host do
     @impl OvcsBridge
-    # Host: same supervision shape as target, but `BNO085.Dummy`
+    # Host: same supervision shape as target, but `OvcsDrivers.Imu.Dummy`
     # stands in for `BNO085.I2C` so the IMU publish path is
     # exercised end-to-end without an attached sensor. Endpoint
     # defaults to 127.0.0.1; override via `ZENOH_ENDPOINT_IP`.
@@ -55,8 +55,8 @@ defmodule RosBridge do
         {RosBridge.ZenohClient, endpoint_ip: config.zenoh_endpoint_ip},
         heartbeat_child(),
         {RosBridge.JoyInterpreter, []},
-        {BNO085.Dummy, []},
-        {RosBridge.ImuPublisher, [driver: BNO085.Dummy]}
+        {OvcsDrivers.Imu.Dummy, []},
+        {RosBridge.ImuPublisher, [driver: OvcsDrivers.Imu.Dummy]}
       ]
     end
   else

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -206,7 +206,7 @@ Provides integration with ROS 2 for autonomous driving research. It:
 - Holds a single Zenoh session (`ZenohClient`) and exposes a `publish/4` + `subscribe/4` API to the rest of the bridge. Handles lazy publisher / liveliness-token declaration, reconnect with stable per-publisher GIDs, and subscriber pid monitoring. See [`bridges/ros_bridge/README.md`](../bridges/ros_bridge/README.md) for the wire-format details.
 - Publishes a `std_msgs/String` heartbeat onto the ROS 2 graph every 5 s via `RosBridge.Heartbeat`, so consumers can see the BEAM is alive even when no other topic is flowing.
 - Subscribes to the ROS 2 `joy` topic via the same `ZenohClient` and forwards `sensor_msgs/Joy` axes onto the CAN bus through `JoyInterpreter` → Cantastic emitters (`ros_control0`/`ros_control1`).
-- Publishes `sensor_msgs/Imu` from any `OvcsDrivers.Imu` driver via `RosBridge.ImuPublisher`. The host arm runs `BNO085.Dummy` and the target arm runs `BNO085.I2C` against a physical sensor; swapping in a future ICM-20948 (or any other conforming IMU) is a one-line supervisor change.
+- Publishes `sensor_msgs/Imu` from any `OvcsDrivers.Imu` driver via `RosBridge.ImuPublisher`. The host arm runs the kind-level `OvcsDrivers.Imu.Dummy` stub and the target arm runs `BNO085.I2C` against a physical sensor; swapping in a future ICM-20948 (or any other conforming IMU) is a one-line supervisor change.
 
 ## Controllers
 

--- a/libraries/ovcs_drivers/README.md
+++ b/libraries/ovcs_drivers/README.md
@@ -24,7 +24,7 @@ Current kinds:
 
 | Kind                  | Behaviour                | Sample / output struct          | Drivers          |
 |-----------------------|--------------------------|---------------------------------|------------------|
-| IMU                   | `OvcsDrivers.Imu`        | `OvcsDrivers.Imu.Sample`        | `BNO085.I2C`, `BNO085.Dummy` |
+| IMU                   | `OvcsDrivers.Imu`        | `OvcsDrivers.Imu.Sample`        | `BNO085.I2C` (+ `OvcsDrivers.Imu.Dummy` stub) |
 
 New kinds land alongside their first concrete driver — defining a
 behaviour with zero implementations is dead code; wait until you have
@@ -35,10 +35,11 @@ a chip driver to anchor the contract.
 ```
 lib/
   imu.ex                          # OvcsDrivers.Imu behaviour
-  imu/sample.ex                   # %OvcsDrivers.Imu.Sample{kind, x, y, z, w}
+  imu/
+    sample.ex                     # %OvcsDrivers.Imu.Sample{kind, x, y, z, w}
+    dummy.ex                      # OvcsDrivers.Imu.Dummy — kind-level fixture stub
   bno085/                         # one driver, implements OvcsDrivers.Imu
     i2c.ex
-    dummy.ex
   <next_chip>/...
 ```
 

--- a/libraries/ovcs_drivers/lib/imu/dummy.ex
+++ b/libraries/ovcs_drivers/lib/imu/dummy.ex
@@ -1,10 +1,13 @@
-defmodule BNO085.Dummy do
+defmodule OvcsDrivers.Imu.Dummy do
   @moduledoc """
-  Host-side stand-in for `BNO085.I2C`. Implements the
-  `OvcsDrivers.Imu` behaviour, emitting one of each sample kind on a
-  10 ms loop so consumers can be exercised end-to-end without an
-  attached sensor. Same contract as the real driver — pre-scaled SI
-  units, generic envelope.
+  Kind-level fixture stub. Implements `OvcsDrivers.Imu` and emits
+  one of each `OvcsDrivers.Imu.Sample` kind on a 10 ms loop so
+  consumers can be exercised end-to-end without an attached sensor
+  — same contract as any real driver, pre-scaled SI units.
+
+  Useful for `./ovcs run` on a developer laptop and for any test
+  that wants a steady stream of plausible IMU samples without
+  spinning up real hardware.
   """
   @behaviour OvcsDrivers.Imu
 

--- a/libraries/ovcs_drivers/test/bno085/i2c_test.exs
+++ b/libraries/ovcs_drivers/test/bno085/i2c_test.exs
@@ -89,7 +89,8 @@ defmodule BNO085.I2CTest do
   describe "parse_cargo/1 + build_sample/1 — full intake path" do
     test "raw accelerometer cargo bytes → fully-scaled Sample" do
       # Same accel cargo as the parse test above; result should match
-      # `BNO085.Dummy`'s static fixture once divided by Q8 = 256.
+      # `OvcsDrivers.Imu.Dummy`'s static accel fixture once divided
+      # by Q8 = 256.
       cargo = <<14, 0, 3, 0, 0x01, 1, 2, 0, 0xD0, 0xFF, 0xD9, 0xFF, 0xA8, 0xFF>>
       # Raw int16 LE: 0xFFD0 = -48, 0xFFD9 = -39, 0xFFA8 = -88.
 


### PR DESCRIPTION
## Summary

The stub never emulated anything BNO-specific — no SH-2, no Q-point conversion, no I²C, no reset semantics. It just emits three pre-scaled `%OvcsDrivers.Imu.Sample{}`s on a 10 ms loop. The `BNO085.*` namespace was misleading; any future IMU driver (ICM-20948, MPU-9250, …) would have wanted a parallel `*.Dummy` doing the exact same thing.

Promote it to a kind-level fixture:

```
libraries/ovcs_drivers/lib/
  imu.ex                 # OvcsDrivers.Imu behaviour
  imu/
    sample.ex            # OvcsDrivers.Imu.Sample
    dummy.ex             # OvcsDrivers.Imu.Dummy   ← was BNO085.Dummy
  bno085/
    i2c.ex               # real chip driver only
```

Cleaner extraction path too — when `BNO085.*` eventually lifts to its own standalone library, the dummy stays in `ovcs_drivers` where the kind contract is anchored, instead of dragging a hand-rolled fixture along.

## Diff scope

- `git mv` of the dummy file (75% similarity retained).
- Module rename + moduledoc rewrite (no longer claims to be a "BNO085 stub").
- `RosBridge.children/0` host arm: one line, `{BNO085.Dummy, …}` → `{OvcsDrivers.Imu.Dummy, …}`. Target arm unchanged.
- Docs: `libraries/ovcs_drivers/README.md` layout + driver-kinds table, `docs/applications.md` ros_bridge IMU bullet, one comment in `i2c_test.exs`.

5 files, +20 / -15.

## Test plan

- [x] `mix compile --warnings-as-errors` clean in `libraries/ovcs_drivers`, `bridges/ros_bridge`, and `bridges/firmware`.
- [x] `mix test` 8/8 in `libraries/ovcs_drivers` (BNO085 SH-2 parse + Q-point scaling).
- [x] `mix test --no-start` 4/4 in `bridges/ros_bridge` (Imu codec).
- [x] End-to-end: `./ovcs run ovcs_mini` logs `publishing … (driver OvcsDrivers.Imu.Dummy)` and `ros2 topic info -v /imu` shows the publisher coming from `ovcs_bridge`. Wire bytes unchanged (the dummy fixture values are identical to what `BNO085.Dummy` was emitting).