### PR TITLE
docs + ci: post-migration cleanup, and CI for the ROS 2 stacks

### DIFF
--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -1,0 +1,82 @@
+name: ROS 2
+
+# The ROS 2 side had no CI at all. The vehicle stack is built by balena
+# from `ros2/vehicule/`, so a broken Dockerfile or a compose file that
+# does not interpolate only surfaced on deploy — the same shape of hole
+# as firmware not being built on pull requests, which cost us four
+# rounds of red CI before it was closed.
+#
+# Two levels, cheapest first:
+#
+#   * `compose-config` validates every compose file in seconds. It
+#     catches the mistakes that are both most likely and most annoying:
+#     a typo in a service, a `${VAR:?}` with nothing to satisfy it, an
+#     invalid profile.
+#   * `image` actually builds the shared ROS image. Every service on
+#     both sides of the fabric runs it (`foxglove_bridge` on the
+#     vehicle; `ros2` / `joy` / `calibrator` on the base station), so it
+#     is the one whose breakage would ground everything.
+#
+# Deliberately not built here: `ros2/simulation`, which pulls Gazebo in
+# through the ROS vendor packages and is far too heavy for per-PR CI.
+# If it starts breaking, give it its own scheduled workflow rather than
+# putting it in this path.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'ros2/**'
+      - '.github/workflows/ros2.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ros2-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compose-config:
+    name: compose config
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        stack: [base, vehicule, simulation]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: docker compose config
+        working-directory: ros2/${{ matrix.stack }}
+        run: |
+          # The base station reads ZENOH_ENDPOINT_IP from a .env that is
+          # deliberately not committed (it holds a site-specific vehicle
+          # address), and the vehicle stack gets its configuration from
+          # balena device variables. Supply a placeholder so
+          # interpolation resolves and a genuinely malformed file is
+          # still the only way this fails.
+          export ZENOH_ENDPOINT_IP=127.0.0.1
+          export FOXGLOVE_BRIDGE_PORT=8765
+          # --profile '*' is not a thing, so name them: a service behind
+          # a profile is otherwise skipped entirely and never validated.
+          docker compose --profile standalone --profile calibration config -q \
+            || docker compose config -q
+
+  image:
+    name: build the shared ROS image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build ros2/vehicule/image
+        uses: docker/build-push-action@v6
+        with:
+          context: ros2/vehicule/image
+          push: false
+          # Layer cache in the Actions cache, so a PR that does not touch
+          # the Dockerfile reuses the apt layer rather than re-fetching
+          # the ROS package set every run.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ovcs/
 |   +-- express_lrs/              MAVLink v2 telemetry reader (ExpressLRS)
 |   +-- msp_osd/                  MSP / DisplayPort OSD stack for MSP-compatible VTXs
 |
-+-- ros2/                       ROS 2 Jazzy + Zenoh router compose stacks: vehicule/ (balenaOS) and base/ (dev box)
++-- ros2/                       ROS 2 Lyrical + Zenoh router compose stacks: vehicule/ (balenaOS) and base/ (dev box)
 +-- cli/                        Rust source for the `ovcs` CLI (binary at cli/ovcs)
 +-- scripts/                    Utility scripts (setup_can.sh, bind_remote_can.rb, ...)
 +-- candumps/                   CAN bus capture logs for offline testing and replay

--- a/bridges/ros_bridge/README.md
+++ b/bridges/ros_bridge/README.md
@@ -205,7 +205,7 @@ stack up:
 
 ```sh
 cd ros2/base && docker compose exec ros2 bash -lc '
-  source /opt/ros/jazzy/setup.bash
+  source /opt/ros/*/setup.bash
   ros2 topic list
   ros2 topic info -v /ovcs_heartbeat
   ros2 topic echo /ovcs_heartbeat std_msgs/msg/String

--- a/bridges/ros_bridge/test/support/golden_cdr.md
+++ b/bridges/ros_bridge/test/support/golden_cdr.md
@@ -4,9 +4,10 @@ CDR bodies (no encapsulation header) for the message shapes exercised
 by `marker_test.exs`, `detection3d_test.exs`,
 `sensor_msgs/msg/camera_info_test.exs` and
 `stereo_msgs/disparity_image_test.exs`. They are this
-codebase's own encoder output, **validated against ROS 2 Jazzy** by
-round-tripping through `rclpy.serialization.deserialize_message` and
-checking every field came back correct.
+codebase's own encoder output, **validated against a real ROS 2
+runtime** by round-tripping through
+`rclpy.serialization.deserialize_message` and checking every field came
+back correct. Originally against Jazzy; re-verified on Lyrical.
 
 ## Why not rclpy's bytes directly
 
@@ -32,7 +33,7 @@ is deserialisation by the real ROS runtime, not arithmetic.
 ## Regenerating
 
 Needs the `ovcs-ros2` container running (`ros2/base`, image
-`ovcs/ros2:jazzy`) — it carries both `visualization_msgs` and
+`ovcs/ros2:lyrical`) — it carries both `visualization_msgs` and
 `vision_msgs`.
 
 1. Encode the fixtures with this repo's modules and dump them as
@@ -45,8 +46,12 @@ Needs the `ovcs-ros2` container running (`ros2/base`, image
    returns wrong values.
 3. Only once every entry round-trips, write the JSON here.
 
-Type hashes come from `/opt/ros/jazzy/share/<pkg>/msg/<Msg>.json` in
-the same container, never from memory, and are per-distro.
+Type hashes come from `/opt/ros/<distro>/share/<pkg>/msg/<Msg>.json` in
+the same container, never from memory. The hash is derived from the
+message *definition*, so it only changes when the definition does — not
+on every distro bump, despite the per-distro path. All seven hashes this
+bridge declares were re-checked against Lyrical after the move from
+Jazzy and every one still matched.
 
 ## The stereo vectors
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Index for the Open Vehicle Control System guides. For a high-level project overv
 ### Hardware
 
 - [Hardware Architecture](./hardware_architecture.md) — design principles, component layout, CAN bus topology and bitrates.
-- [Toolchain and OTP Versions](./toolchain_and_otp.md) — why the host Elixir/OTP pin in `mise.toml` is coupled to each Nerves target's OTP version, and the two ways out of the current split.
+- [Toolchain and OTP Versions](./toolchain_and_otp.md) — why the host Elixir/OTP pin in `mise.toml` is coupled to each Nerves target's OTP version, what the A/B partition layout requires of firmware, and how to follow a system fork upstream again.
 - [ROS Compute Node](./ros_compute_node.md) — the OVCS Mini's non-Nerves Pi: why it exists, the immutable OS choice (balenaOS), the vehicule/base compose split, and how it wires into the Zenoh fabric.
 - [ROS Perception Detection](./ros_perception_detection.md) — object detection on the Hailo-8: why detection and not disparity, what it costs the stereo rate, how a 2D box becomes a 3D position, and the two topics it publishes.
 - [Running on Hardware](./running_hardware.md) — Nerves targets, the `ovcs` CLI for build / burn / OTA upload, attach / connect for runtime debugging.

--- a/docs/ros_compute_node.md
+++ b/docs/ros_compute_node.md
@@ -38,7 +38,7 @@ both sides live in [`ros2/`](../ros2/README.md).
 
 | Item | Choice | Why |
 |---|---|---|
-| Board | Raspberry Pi 5, 8 GB | ROS 2 Jazzy + Foxglove + perception nodes want the headroom |
+| Board | Raspberry Pi 5, 8 GB | ROS 2 Lyrical + Foxglove + perception nodes want the headroom |
 | Storage | NVMe (HAT) or USB SSD | ROS images are multi-GB and container writes destroy SD cards |
 | Clock | Pi 5 RTC connector + battery, plus NTP | see [Clock](#clock) |
 | Network | the Pi *is* the vehicle network — see [Networking](#networking) | the bridges' router IP is baked into firmware, so it has to be an address we choose |

--- a/docs/ros_perception_detection.md
+++ b/docs/ros_perception_detection.md
@@ -76,7 +76,7 @@ The first two are both published because neither covers the other.
 Foxglove's 3D panel **does not support `vision_msgs`** — publishing
 only that puts the data on the wire with nothing to draw it. Markers,
 conversely, carry no class label, score or covariance in
-machine-readable form. (`ros-jazzy-vision-msgs` is installed in the
+machine-readable form. (`ros-lyrical-vision-msgs` is installed in the
 `vehicule` image, so `foxglove_bridge` can deserialise the
 Detection3DArray too.)
 
@@ -106,7 +106,7 @@ message, and `LINE_LOOP` closes a rectangle in four points where a
 `LINE_LIST` of segment pairs needs eight.
 
 The cost is a dependency. `foxglove_msgs` is not in a ROS base
-install, so `ros-jazzy-foxglove-msgs` is installed in
+install, so `ros-lyrical-foxglove-msgs` is installed in
 `ros2/vehicule/image/Dockerfile` — **without it `foxglove_bridge`
 cannot resolve the type and never advertises the topic**. Both the
 `vehicule` and `base` composes build from that one Dockerfile, so a
@@ -149,7 +149,7 @@ From the laptop, with the `ovcs-ros2` container up:
 
 ```sh
 docker exec ovcs-ros2 bash -lc \
-  'source /opt/ros/jazzy/setup.bash; export RMW_IMPLEMENTATION=rmw_zenoh_cpp
+  'source /opt/ros/*/setup.bash; export RMW_IMPLEMENTATION=rmw_zenoh_cpp
    ros2 topic hz /stereo/detections
    ros2 topic echo /stereo/detections --once'
 ```

--- a/docs/toolchain_and_otp.md
+++ b/docs/toolchain_and_otp.md
@@ -22,172 +22,105 @@ is why `firmware.yml` runs on pull requests as well as pushes to main.
 
 ## Current state
 
-Each target system pins its own `nerves_system_br`, which fixes its OTP
-version. Every system currently on main locks **1.29.3**:
+The fleet is on **OTP 28**. Every system tracks upstream v2.0.3
+(`nerves_system_br` 1.33.7, Erlang/OTP 28.5), and `mise.toml` pins
+Erlang 28.4.1 / Elixir 1.19.5-otp-28 to match:
 
-| Target | Used by | `nerves_system_br` |
+| Target | Used by | System release |
 |---|---|---|
-| `ovcs_base_can_system_rpi3a` | `bridges/firmware` (radio control) | 1.29.3 |
-| `ovcs_base_can_system_rpi4` | `bridges/firmware` (ros), `vms/firmware` | 1.29.3 |
-| `ovcs_base_can_system_rpi5` | `infotainment/firmware` | 1.29.3 |
+| `ovcs_base_can_system_rpi3a` | `bridges/firmware` (radio control) | v2.0.4 |
+| `ovcs_base_can_system_rpi4` | `bridges/firmware` (ros), `vms/firmware` | v2.0.4 |
+| `ovcs_base_can_system_rpi5` | `infotainment/firmware` | v2.0.4 |
+| `rpi5` (`ovcs_bridges_system_rpi5`) | `bridges/firmware` (perception) | v2.0.8 |
 
-`mise.toml` on main pins Erlang 27.3, and the `Firmware` workflow builds
-all of these green — so 1.29.3 is the OTP 27 line, and the host matches
-every target today.
+Every one is pinned to a **tag**. They used to be bare `github:`
+references tracking each fork's default branch, which is a trap worth
+not re-setting: a release on the fork moves the branch, and the next
+`mix deps.update` silently changes the OTP major with no warning.
 
-The perception work (PR #26) adds a fourth: the `rpi5` target, backed by
-`ovcs_bridges_system_rpi5` v2.0.8, which locks `nerves_system_br`
-1.33.7. Per that branch's own `mise.toml` note, upstream
-`nerves_system_rpi5` v2.0.x ships OTP 28 and Elixir 1.19, and the branch
-raises the host pin to match.
+`bridges/firmware` returns only the active target's system from `deps/0`
+(`system_deps/1`) rather than listing all of them, so each `MIX_TARGET`
+resolves independently. That is still needed: the perception Pi 5 is on
+1.33.7 while the base systems are on their own line, and Mix evaluates
+the whole dep graph regardless of the `:targets` keyword.
 
-The perception bridge needs the Pi 5 system's OTP 28 line: it is rebased
-on upstream `nerves_system_rpi5` v2.0.x, which is what ships libcamera
-with PISP pipeline support — the whole point of Camera Module 3 stereo
-capture on the Pi 5.
+## What the v2.0 move brought with it
 
-`bridges/firmware` handles the resulting `nerves_system_br` conflict by
-returning only the active target's system from `deps/0`
-(`system_deps/1`), so each `MIX_TARGET` resolves independently instead
-of Mix trying to satisfy 1.29.3 and 1.33.7 at once.
+Upstream v2.0.0 was not just an OTP bump — it changed the MicroSD/eMMC
+layout to A/B firmware slots with automatic rollback, one-way. Two
+consequences are now permanent features of this repo, and both are easy
+to break by accident:
 
-That solves *dependency resolution*. It does not solve the host pin:
-`mise.toml` can only name one Erlang/Elixir, so raising it to OTP 28 for
-the Pi 5 leaves the rpi3a/rpi4 firmwares built by a host newer than the
-ERTS they ship.
+1. **Firmware marks itself good.** An image that does not call
+   `Nerves.Runtime.validate_firmware/0` is reverted on the next boot.
+   `OvcsVehicle.FirmwareValidator` does this, wired into `vms_firmware`,
+   `bridge_firmware` and `infotainment_firmware` on target only. Remove
+   it and every OTA update silently rolls back — including NervesHub's.
+2. **Boot overlays come in A/B pairs.** `cmdline-a.txt` (rootfs on
+   `mmcblk0p5`) and `cmdline-b.txt` (`p6`) under
+   `vehicles/*/priv/firmware/**`. The pairs are not interchangeable
+   between roles: infotainment uses `console=tty3` with `logo.nologo`,
+   radio-control carries `brcmfmac.feature_disable`. Derive a new pair
+   from its own original, never from a template.
 
-## The decision: bump the fleet
+The per-target `fwup.conf` files under `<firmware>/targets/<target>/`
+encode that partition layout, so they are regenerated from the system's
+own v2.0 `fwup.conf` rather than hand-patched. The only OVCS changes on
+top are the three `${VEHICLE_FIRMWARE_DIR}` redirects (`cmdline-a.txt`,
+`cmdline-b.txt`, `config.txt`) and the CAN/SPI device-tree overlays each
+firmware needs. Vehicles no longer carry their own copies — they were
+byte-identical duplicates of the target defaults, and
+`resolve_firmware_file` falls through to those, keying
+`VEHICLE_FIRMWARE_DIR` on `config.txt` rather than `fwup.conf`.
 
-All three base systems move to upstream **v2.0.3** (`nerves_system_br`
-1.33.7, Erlang/OTP 28.5), and the whole repo runs one OTP 28 toolchain.
-v2.0.3 is chosen rather than the newest tag because it is exactly the
-base `ovcs_bridges_system_rpi5` v2.0.8 already sits on — so the fleet
-ends up on a single `nerves_system_br`, not two.
+## Migrating a system fork again
 
-The alternative considered and rejected was per-project toolchains (a
-directory-scoped `mise.toml` keeping OTP 27 for the rpi3a/rpi4
-projects). It avoids reflashing, at the cost of two toolchains, and it
-only defers this work.
+The recipe, should a fork need to follow upstream again:
 
-### This is a partition-layout migration, not just an OTP bump
+1. Fetch upstream tags into their **own namespace**
+   (`git fetch upstream 'refs/tags/*:refs/tags/up/*'`) and take the base
+   from `git merge-base main upstream/main`. The forks carry their own
+   `v1.29.x`/`v2.0.x` tags, whose names collide with upstream's, and
+   `git fetch --tags` will not overwrite an existing tag — so a naive
+   `git diff v1.29.3 main` compares fork-to-fork and reports a
+   misleading delta.
+2. Branch from the upstream tag and re-apply the OVCS delta, which is
+   thin: CAN packages in `nerves_defconfig`, CAN/SPI kernel modules in
+   `linux-*.defconfig` (renamed between upstream releases, so re-apply
+   rather than copy the file), and package identity in `mix.exs`.
+3. `release.yml` builds the system with Buildroot on `ubuntu-22.04` and
+   attaches the portable tarball to the release for the tag that
+   triggered it. Newer runners ship GCC 13+ and CMake 4, which trip
+   implicit-function-declaration errors in gnulib-derived host packages.
+4. Tag it. Create the tag against an explicit SHA and check it points
+   where you think before pushing — with colliding tag names in the
+   repo, an unguarded `git tag` failure followed by `git push <tag>` will
+   happily publish *upstream's* tag onto the fork.
+5. Point the monorepo's system deps at the new tags and let the
+   `Firmware` workflow build all four matrix entries.
 
-Upstream v2.0.0 is a **breaking, one-way** change: the MicroSD/eMMC
-layout gains A/B firmware slots with automatic rollback. Quoting the
-upstream changelog:
+Then **reflash every affected board.** The partition change cannot be
+delivered as an OTA update, and a device left on the old layout cannot
+take the new firmware.
 
-> **IMPORTANT** This is a one way upgrade. Going back to the old
-> partitioning requires manually reflashing of the RPi's storage.
+## Why the fleet bump rather than per-project toolchains
 
-Two consequences land squarely on this repo, and both are easy to miss:
+The alternative was a directory-scoped `mise.toml` keeping OTP 27 for
+the rpi3a/rpi4 projects, so only the Pi 5 moved. It avoids reflashing,
+at the cost of two toolchains installed, contributors having to know
+which shell they are in, and CI having to pick the right one per job —
+and it only defers the work. The fleet bump was chosen for a single
+toolchain and a single `nerves_system_br` across every target.
 
-1. **Firmware must mark itself good.** From v2.0.0, an image that does
-   not call `Nerves.Runtime.validate_firmware/0` is reverted to the
-   previous version on the next boot. Nothing in this repo calls it
-   today. Miss this and *every* OTA update silently rolls back —
-   including NervesHub updates, which makes this a hard prerequisite
-   for the NervesHub work rather than a follow-up to it.
-2. **Every per-vehicle boot overlay needs an A/B pair.** Upstream
-   replaced `cmdline.txt` with `cmdline-a.txt` + `cmdline-b.txt`
-   (rootfs on `mmcblk0p5` vs `p6`). There are nine such overlays under
-   `vehicles/*/priv/firmware/**` on main, plus the perception bridge's
-   on its own branch. They are not interchangeable: the infotainment
-   ones use `console=tty3` with `logo.nologo`, and the radio-control
-   ones carry `brcmfmac.feature_disable`, so each pair has to be
-   derived from its own original rather than copied from a template.
+The reflash cost was accepted deliberately: the v2.0 partition change
+makes it unavoidable regardless of when it happens.
 
-### The OVCS delta each fork re-applies
-
-The forks are thin, which is what makes this tractable. Ignoring
-`LICENSES/`, `REUSE.toml` and `README.md` boilerplate, the functional
-delta over upstream is:
-
-| File | What OVCS adds |
-|---|---|
-| `nerves_defconfig` | `LIBSOCKETCAN`, `CAN_UTILS`, `SOCKETCAND`, `IPROUTE2`, `IPTABLES`, eudev for dynamic device nodes; `BR2_NERVES_SYSTEM_NAME` rename |
-| `linux-*.defconfig` | `CAN`, `CAN_VCAN`, `CAN_MCP251X`, `CAN_MCP251XFD`, `SERIAL_SC16IS7XX` (SPI variant on, I²C off) |
-| `mix.exs`, `VERSION`, `README.md`, `.gitignore` | package identity |
-
-Measured on `rpi4`: thirteen config lines plus identity. The PWM
-device-tree overlays, the `config.txt` PWM hint and the NVMe kernel
-option used to be carried here and are **upstream's own** as of v2.0.x —
-re-adding them would be duplication.
-
-Three traps, all of which produce a plausible-looking but wrong result:
-
-- **The forks carry their own `v1.29.x` tags**, which collide with
-  upstream's tag names. `git fetch upstream --tags` will not overwrite
-  an existing tag, so `git diff v1.29.3 main` silently compares
-  fork-to-fork and reports an empty or misleading delta. Fetch upstream
-  tags into their own namespace
-  (`git fetch upstream 'refs/tags/*:refs/tags/up/*'`) and take the base
-  from `git merge-base main upstream/main`. Getting this wrong is how
-  the PWM/NVMe rows above came to be attributed to OVCS.
-- The kernel defconfig is renamed upstream (`linux-6.6.defconfig` →
-  `linux-6.12.defconfig`). The delta has to be re-applied to the new
-  file, not carried over wholesale — the surrounding config moved.
-- `fwup.conf` is **generated** from `fwup.conf.eex` by a mix task in
-  v2.0.3. Nothing in the OVCS delta touches it, but if that ever
-  changes, edit the template — the output is overwritten.
-
-### These build in CI
-
-`ovcs_bridges_system_rpi5` already carries a `release.yml` that builds
-the system with Buildroot on `ubuntu-22.04` (90-minute timeout, Nerves
-toolchain artifacts cached) and attaches the portable tarball to the
-release for the tag that triggered it. Copy it into each base system —
-no local Buildroot run or bench build is needed to produce a release.
-
-It pins `ubuntu-22.04` deliberately: newer runners ship GCC 13+ and
-CMake 4, which trip implicit-function-declaration errors in
-gnulib-derived host packages.
-
-### Order of work
-
-Per system repo, `rpi4` first as the pilot (it carries both `vms` and
-the `ros` bridge, so it exercises the most):
-
-1. Branch from upstream `v2.0.3`.
-2. Re-apply the delta in the table above, porting the kernel options
-   onto `linux-6.12.defconfig`.
-3. Restore the fork's identity: `VERSION`, `mix.exs` package name,
-   `BR2_NERVES_SYSTEM_NAME`, `LICENSES/`, `REUSE.toml`, `README.md`.
-4. Add `release.yml` from `ovcs_bridges_system_rpi5`, with a
-   `pull_request` trigger added — see the note below on why
-   `workflow_dispatch` alone is not enough.
-5. Tag `v2.0.3-ovcs.1` (or continue the fork's own series) and let CI
-   build and publish the tarball.
-6. Repeat for `rpi3a` and the infotainment `rpi5`.
-
-Then in this repo, in one PR:
-
-7. Point the three system deps at the new tags.
-8. Add `Nerves.Runtime.validate_firmware/0` to `vms_firmware`,
-   `bridge_firmware` and `infotainment_firmware` — see prerequisite 1
-   above.
-9. Convert the ten remaining `cmdline.txt` overlays to `-a`/`-b` pairs,
-   following the perception bridge's.
-10. Keep `mise.toml` on OTP 28 and confirm the `Firmware` workflow is
-    green for all four matrix entries.
-
-Finally: **reflash every deployed rpi3a/rpi4/rpi5 device.** The
-partition change cannot be delivered as an OTA update, and a device
-left on the old layout cannot take the new firmware.
-
-## Getting a system built the first time
+## A gotcha if a fork ever needs its workflow re-added
 
 `workflow_dispatch` only works once the workflow file is on the
 repository's **default** branch, so a `release.yml` introduced in a pull
-request cannot be dispatched from that pull request. The base branches of
-these forks have no workflows at all today, and no Actions run has ever
-happened in them.
-
-The way out, in order:
-
-1. Land `release.yml` on the fork's `main` on its own. It touches nothing
-   the system builds, so merging it unbuilt is safe.
-2. Then `workflow_dispatch` it against the migration branch — dispatch
-   can target any branch once the file is on the default branch.
-3. Only merge the migration once that run is green.
-
-A `pull_request` trigger is also worth keeping, so later changes are
-built before merge rather than after.
+request cannot be dispatched from that pull request. If a fork has no
+workflows on `main`, land `release.yml` there on its own first — it
+touches nothing the system builds, so merging it unbuilt is safe — then
+dispatch it against the migration branch, and merge the migration only
+once that run is green.

--- a/ros2/README.md
+++ b/ros2/README.md
@@ -1,6 +1,6 @@
 # ROS 2 stack
 
-ROS 2 Jazzy + the Zenoh router, split across the two machines that run
+ROS 2 Lyrical + the Zenoh router, split across the two machines that run
 it. Uses `rmw_zenoh_cpp` so ROS nodes join the same Zenoh fabric the
 Elixir `ros_bridge` already speaks to — no DDS, no multicast, just TCP
 peerings to `zenohd`.
@@ -59,7 +59,7 @@ Smoke-test against the bridge's heartbeat (published by
 
 ```sh
 docker compose exec ros2 bash -lc '
-  source /opt/ros/jazzy/setup.bash
+  source /opt/ros/*/setup.bash
   ros2 topic list                              # should include /ovcs_heartbeat
   ros2 topic echo /ovcs_heartbeat std_msgs/msg/String
 '
@@ -85,7 +85,7 @@ ls /dev/input/js*               # should show js0 — that's your default
 docker compose up -d joy
 
 docker compose exec ros2 bash -lc '
-  source /opt/ros/jazzy/setup.bash
+  source /opt/ros/*/setup.bash
   ros2 topic echo /joy sensor_msgs/msg/Joy   # wiggle a stick to confirm
 '
 ```
@@ -148,8 +148,8 @@ in that file lists each omission and why.
   copied to the device once; `balena push` does not deploy it. See
   [docs/ros_compute_node.md](../docs/ros_compute_node.md#networking).
 - `vehicule/image/Dockerfile` — single image baking
-  `ros-jazzy-rmw-zenoh-cpp`, `ros-jazzy-foxglove-bridge`,
-  `ros-jazzy-joy-linux`, `gettext-base`, the Python `eclipse-zenoh`
+  `ros-lyrical-rmw-zenoh-cpp`, `ros-lyrical-foxglove-bridge`,
+  `ros-lyrical-joy-linux`, `gettext-base`, the Python `eclipse-zenoh`
   client, and the Zenoh session template. Sets a proper `ENTRYPOINT` +
   default `CMD`; per-service launchers are picked via compose's
   `command:` field. Rebuild after changing it: `docker compose build`

--- a/ros2/simulation/Dockerfile
+++ b/ros2/simulation/Dockerfile
@@ -1,4 +1,4 @@
-# Gazebo Harmonic + ROS 2 Jazzy image for simulating the OVCS Mini.
+# Gazebo Jetty + ROS 2 Lyrical image for simulating the OVCS Mini.
 #
 # Separate from the vehicle image on purpose. This one carries Gazebo
 # and its GUI stack — hundreds of megabytes that must never end up on

--- a/ros2/vehicule/image/Dockerfile
+++ b/ros2/vehicule/image/Dockerfile
@@ -1,4 +1,4 @@
-# Single ROS 2 Jazzy image powering every service on both sides of the
+# Single ROS 2 Lyrical image powering every service on both sides of the
 # fabric: `foxglove_bridge` on the vehicle (../docker-compose.yml) and
 # `ros2` / `joy` / `calibrator` on the base station
 # (../../base/docker-compose.yml). Each service picks its launcher via

--- a/ros2/vehicule/image/docker/entrypoint.sh
+++ b/ros2/vehicule/image/docker/entrypoint.sh
@@ -6,7 +6,7 @@
 # line and nothing else.
 # Does only the cross-cutting setup every service needs:
 #   1. Render the Zenoh session config from its template.
-#   2. Source the ROS 2 Jazzy overlay so `ros2 …` works.
+#   2. Source the ROS 2 Lyrical overlay so `ros2 …` works.
 # Then `exec`s whatever CMD (or `docker run …` override) was passed —
 # i.e. it is service-agnostic. Per-service launch logic lives in CMD,
 # not here.


### PR DESCRIPTION
Two rounds of migration (OTP 28 fleet bump, Jazzy → Lyrical) left docs describing a state that no longer exists, and the ROS 2 side still had no CI.

## Distro drift

Every `source /opt/ros/jazzy/setup.bash` in the docs would now fail, and package names and the image tag were wrong: `ros-jazzy-*` → `ros-lyrical-*`, `ovcs/ros2:jazzy` → `ovcs/ros2:lyrical`. Shell snippets now use `/opt/ros/*/setup.bash` so the next bump doesn't re-stale them.

Three stale comments the markdown sweep missed, in Dockerfiles and `entrypoint.sh`, which said Jazzy while their `FROM` is `ros:lyrical-ros-base`. The simulation one was doubly wrong — it claimed Gazebo Harmonic when its own comment eight lines below explains the move to Lyrical was made precisely to get **Jetty**.

Left alone on purpose: the Jazzy references in `ros2/simulation/README.md` are the migration rationale, not instructions.

`golden_cdr.md` also claimed type hashes 'are per-distro'. They're derived from the message **definition**, so they change only when the definition does. All seven hashes this bridge declares were checked against Lyrical — **every one matched**, confirming what `ros2/simulation/README.md` already said.

## toolchain_and_otp.md: plan → record

It still read as pending work ('The decision: bump the fleet', a numbered 'Order of work') though the fleet bump shipped. Rewritten to describe what exists (systems at v2.0.4/v2.0.8, tag-pinned, host on OTP 28), what the A/B layout **permanently requires** of firmware — `validate_firmware/0` and the `cmdline-a/b` pairs, both easy to break by accident — and a recipe for following a fork upstream again, including two traps: colliding fork/upstream tag names making a naive diff misleading, and an unguarded tag push publishing *upstream's* tag onto the fork.

The constraint section is unchanged; it's the part that stays true.

## CI for the ROS 2 stacks

The vehicle stack is built by balena, so a broken Dockerfile or a compose file that fails to interpolate only surfaced on deploy — the same gap as firmware not being built on PRs.

- `compose config` for all three stacks in seconds. Profiles are named explicitly, because a service behind one is otherwise skipped and never validated.
- a real build of `ros2/vehicule/image`, the shared image every service on both sides of the fabric runs, with the layer cache in the Actions cache.
- `ros2/simulation` gets compose validation only — it pulls Gazebo through the ROS vendor packages and is far too heavy per-PR.

Verified before committing: all three compose files validate and the image builds clean locally.
