### PR TITLE
fix(cli): stop parsing mix compiler output as probe answers

### DIFF
--- a/cli/src/vehicles.rs
+++ b/cli/src/vehicles.rs
@@ -233,26 +233,56 @@ end
     Ok(addons)
 }
 
+/// Printed by every probe before its payload, so compiler chatter can be
+/// separated from the answer.
+///
+/// `mix run` compiles the project before evaluating `-e`, and that output
+/// goes to stdout: "Compiling 10 files (.ex)", "Generated ovcs_mini app".
+/// Returning raw stdout meant every caller parsed those lines as data.
+/// `host_can_interfaces` took them for interface names and `ovcs can
+/// setup` duly offered to `ip link add dev "Compiling 10 files (.ex)"`;
+/// `has_infotainment` compares the whole output to "yes", so chatter made
+/// it answer no. It only ever misbehaved on a cold build, which is why it
+/// went unnoticed.
+const PROBE_MARKER: &str = "__OVCS_PROBE__";
+
+/// Everything the probe printed after the marker, or `None` if it printed
+/// nothing. Splits on the *last* marker so a snippet that somehow emits it
+/// twice still yields the final payload.
+fn probe_payload(stdout: &str) -> Option<String> {
+    let payload = match stdout.rsplit_once(PROBE_MARKER) {
+        Some((_chatter, payload)) => payload,
+        // No marker: an older/hand-built snippet, or mix failed before
+        // evaluating. Fall back to the whole output rather than losing it.
+        None => stdout,
+    };
+    let trimmed = payload.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 pub(crate) fn run_snippet(path: &Path, snippet: &str) -> Result<Option<String>> {
     let env: HashMap<String, String> =
         std::iter::once(("MIX_ENV".to_string(), "dev".to_string())).collect();
+    let marked = format!("IO.write(\"{PROBE_MARKER}\")\n{snippet}");
     let (code, stdout) = run_capture(
-        &["mix", "run", "--no-start", "--no-deps-check", "-e", snippet],
+        &["mix", "run", "--no-start", "--no-deps-check", "-e", &marked],
         path,
         &env,
     )?;
     if code == 0 {
-        let trimmed = stdout.trim();
-        return Ok(if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        });
+        return Ok(probe_payload(&stdout));
     }
-    retry_with_deps(path, snippet)
+    // The retry gets the same marked snippet: it runs right after a
+    // `deps.get` + `compile`, which is precisely when the chatter this
+    // marker exists to skip is loudest.
+    retry_with_deps(path, &marked)
 }
 
-fn retry_with_deps(path: &Path, snippet: &str) -> Result<Option<String>> {
+fn retry_with_deps(path: &Path, marked: &str) -> Result<Option<String>> {
     let rel = path.strip_prefix(std::env::current_dir()?).unwrap_or(path);
     println!(
         "{}",
@@ -274,17 +304,54 @@ fn retry_with_deps(path: &Path, snippet: &str) -> Result<Option<String>> {
         }
     }
     let (code, stdout) = run_capture(
-        &["mix", "run", "--no-start", "--no-deps-check", "-e", snippet],
+        &["mix", "run", "--no-start", "--no-deps-check", "-e", marked],
         path,
         &env,
     )?;
     if code == 0 {
-        let trimmed = stdout.trim();
-        return Ok(if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        });
+        return Ok(probe_payload(&stdout));
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{probe_payload, PROBE_MARKER};
+
+    // The exact chatter that caused `ovcs can setup ovcs_mini` to offer
+    // to create interfaces named "Compiling 10 files (.ex)".
+    const CHATTER: &str = "Compiling 10 files (.ex)\nGenerated ovcs_mini app\n";
+
+    #[test]
+    fn compiler_chatter_before_the_marker_is_dropped() {
+        let stdout = format!("{CHATTER}{PROBE_MARKER}vcan0\n");
+        assert_eq!(probe_payload(&stdout).as_deref(), Some("vcan0"));
+    }
+
+    #[test]
+    fn a_multi_line_payload_survives_intact() {
+        let stdout = format!("{CHATTER}{PROBE_MARKER}vcan0\nvcan1\n");
+        assert_eq!(probe_payload(&stdout).as_deref(), Some("vcan0\nvcan1"));
+    }
+
+    #[test]
+    fn an_empty_payload_is_none_even_behind_chatter() {
+        // Otherwise the chatter itself reads as the answer — which is how
+        // has_infotainment came to answer "no" on a cold build.
+        let stdout = format!("{CHATTER}{PROBE_MARKER}\n");
+        assert_eq!(probe_payload(&stdout), None);
+    }
+
+    #[test]
+    fn output_without_a_marker_is_passed_through() {
+        // mix failing before it evaluates -e must not silently look like
+        // an empty answer.
+        assert_eq!(probe_payload("yes").as_deref(), Some("yes"));
+    }
+
+    #[test]
+    fn the_last_marker_wins() {
+        let stdout = format!("{PROBE_MARKER}stale{PROBE_MARKER}fresh");
+        assert_eq!(probe_payload(&stdout).as_deref(), Some("fresh"));
+    }
 }

--- a/ros2/simulation/README.md
+++ b/ros2/simulation/README.md
@@ -102,9 +102,24 @@ runs unchanged against the simulator. Only the camera driver differs:
 same frames a physical driver does.
 
 ```sh
-cd bridges/ros_bridge
-VEHICLE=OvcsMini OVCS_SIM=1 ZENOH_ENDPOINT_IP=127.0.0.1 iex -S mix
+./ovcs can setup ovcs_mini          # once — Cantastic needs vcan0 to exist
+
+cd bridges/firmware
+VEHICLE=OvcsMini OVCS_SIM=1 ZENOH_ENDPOINT_IP=127.0.0.1 \
+  BRIDGE_FIRMWARE_ID=ros_perception CAN_NETWORK_MAPPINGS=ovcs:vcan0 \
+  iex -S mix
 ```
+
+`bridges/firmware`, not `bridges/ros_bridge`: the bridge library has no
+`config/` of its own, so `CAN_NETWORK_MAPPINGS` is never read there and
+Cantastic dies with "CAN network mappings are missing from the Cantastic
+configuratiion". The firmware project is what `./ovcs run` starts, and
+its `config/runtime.exs` is where that variable is consumed.
+
+`BRIDGE_FIRMWARE_ID` is required too. Without it `firmware_id/0` falls
+back to `"ros"`, which selects `ros_bridge_config(:host, "ros")` — the
+joy/IMU wiring — and the stereo pipeline never starts at all, with no
+error to say why.
 
 `OVCS_SIM` selects the simulated wiring, so it cannot be picked up by
 accident on the vehicle. No `:hailo_detector` there — a workstation


### PR DESCRIPTION
Two bugs in running the whole stack locally against the Gazebo simulator.

## The CLI read compiler chatter as data

The CLI probes a vehicle by running a snippet through `mix run -e` and parsing stdout. mix compiles the project first, and *that* goes to stdout too — so on a cold build:

```
$ ./ovcs can setup ovcs_mini
OvcsMini requires:
  · Compiling 10 files (.ex)
  · Generated ovcs_mini app
  · vcan0

Will run as root:
  · create Compiling 10 files (.ex)
  · create Generated ovcs_mini app
  · create vcan0
```

One successful sudo away from `ip link add dev "Compiling 10 files (.ex)"`.

**It is a class bug, not one call site.** Five callers parse `run_snippet`'s output; `host_can_interfaces` was just the visible one. `has_infotainment` compares the entire output to `"yes"`, so on a cold build it answered **no** — a vehicle would silently lose its infotainment side, with nothing to indicate why.

Fixed at the source: every probe prints a marker before its payload, and only what follows the last marker is parsed. Output with no marker passes through unchanged, so a mix failure *before* evaluation can't masquerade as an empty answer.

The retry path gets the same marked snippet. It runs immediately after `deps.get` + `compile` — precisely when the chatter is loudest — so leaving it unmarked would have fixed only the warm case, which was never broken.

Five tests, using the real chatter above. Verified end to end by deleting the vehicle's build directory and re-running: one clean answer.

## The simulation README's command could not work

It said to run the perception pipeline from `bridges/ros_bridge`. That library has no `config/` of its own, so `CAN_NETWORK_MAPPINGS` is never read and Cantastic refuses to start:

```
** (Mix) Could not start application cantastic: ...
   ** (EXIT) "CAN network mappings are missing from the Cantastic configuratiion"
```

It must run from `bridges/firmware` — what `./ovcs run` starts, and where `config/runtime.exs` consumes that variable. Two more vars were missing: `CAN_NETWORK_MAPPINGS`, and `BRIDGE_FIRMWARE_ID=ros_perception`. Without the latter, `firmware_id/0` falls back to `"ros"` and starts the joy/IMU wiring instead of the stereo pipeline — silently, with no error.

Also documents the `./ovcs can setup ovcs_mini` prerequisite.

## The corrected command works

With it, the pipeline reproduces the README's own reference numbers against `workshop.sdf`:

| | README | this run |
|---|---|---|
| rate | 30.3 Hz | 31.9 Hz |
| depth coverage | 61.2% | 61.2% |
| median | 0.81 m | 0.81 m |
| p75 | 1.75 m | 1.75 m |

Coverage to the decimal and both quantiles to the centimetre — which, as the README says, is the check that validates SGBM geometry rather than just that pixels arrived.

`fmt`, `clippy -D warnings`, `build` and `test` (9 tests) all pass.
