### PR TITLE
fix(vms_core): the ROS throttle never expired

### DIFF
--- a/vms/core/lib/vms_core/components/ovcs/ros_control/throttle.ex
+++ b/vms/core/lib/vms_core/components/ovcs/ros_control/throttle.ex
@@ -1,11 +1,51 @@
 defmodule VmsCore.Components.OVCS.ROSControl.Throttle do
   @moduledoc """
-    Control throttle/breaking based on ROS control's input
+  Control throttle/breaking based on ROS control's input.
+
+  ## The throttle expires; it is not held
+
+  `handle_frame` is the only thing that moves `raw_value`, and `emit/1`
+  runs every 10 ms regardless. Without an expiry that combination
+  means a ROS bridge which stops talking leaves the last commanded
+  throttle applied *forever* — the vehicle keeps driving until
+  something physical stops it. That is not a hypothetical: it is what
+  happens when the bridge BEAM crashes, when Zenoh partitions, or when
+  the CAN link is cut.
+
+  So this component asks `Cantastic.ReceivedFrameWatcher` to tell it
+  when `ros_control1` stops arriving, and zeroes the request when it
+  does. `%{errors: true}` on the subscription is what opts into those
+  events; the default is `false`, which is why nothing arrived before.
+
+  Detection takes roughly 50 ms: the frame declares `frequency: 10`
+  (Cantastic's `frequency` is a *period in milliseconds*, so 100 Hz),
+  the watcher tolerates `allowed_frequency_leeway` of 10 ms on top, and
+  needs `allowed_missing_frames` — 5 by default — consecutive late
+  checks before it declares the frame dead. At 2 m/s that is about
+  10 cm of travel.
+
+  Recovery needs no code: the next frame to arrive sets `raw_value`
+  again.
+
+  ## Only the throttle expires
+
+  `ROSControl.Steering` deliberately holds its last value rather than
+  centring. Removing propulsion is what makes the vehicle safe;
+  snapping the wheels straight mid-corner at speed is a new hazard
+  rather than a mitigation, and it would be a violent input on OVCS1 in
+  particular. It is also consistent with how a human takes over —
+  `VmsCore.Managers.ControlLevel` switches the steering *source*, so
+  this component's value stops being read at all.
+
+  `ROSControl.Direction` is likewise untouched: direction is inert once
+  throttle is zero.
   """
   use GenServer
-  alias Cantastic.{Receiver, Frame, Signal}
+  alias Cantastic.{Receiver, Frame, ReceivedFrameWatcher, Signal}
   alias Decimal, as: D
   alias OvcsBus, as: Bus
+
+  require Logger
 
   @loop_period 10
   @zero D.new(0)
@@ -17,7 +57,11 @@ defmodule VmsCore.Components.OVCS.ROSControl.Throttle do
 
   @impl true
   def init(_) do
-    :ok = Receiver.subscribe(self(), :ovcs, "ros_control1")
+    # `%{errors: true}` subscribes to `handle_missing_frame` as well as
+    # `handle_frame`; `enable/2` starts the watcher's timer. Both are
+    # needed — see `Cantastic.ReceivedFrameWatcher`.
+    :ok = Receiver.subscribe(self(), :ovcs, "ros_control1", %{errors: true})
+    :ok = ReceivedFrameWatcher.enable(:ovcs, "ros_control1")
     {:ok, timer} = :timer.send_interval(@loop_period, :loop)
 
     {:ok,
@@ -42,6 +86,24 @@ defmodule VmsCore.Components.OVCS.ROSControl.Throttle do
     %{"throttle" => %Signal{name: "throttle", value: raw_value}} = signals
     {:noreply, %{state | raw_value: raw_value}}
   end
+
+  # The watcher fires this once per outage, on the transition to dead,
+  # so it does not need rate limiting.
+  def handle_info({:handle_missing_frame, :ovcs, "ros_control1"}, state) do
+    Logger.warning(
+      "#{__MODULE__}: ros_control1 stopped arriving — throttle zeroed. " <>
+        "The ROS bridge is not commanding this vehicle."
+    )
+
+    {:noreply, %{state | raw_value: 0}}
+  end
+
+  # Anything else is ignored rather than fatal. This process is the
+  # throttle path; a stray message — a late reply, a monitor going
+  # down — crashing it means a gap in throttle emission, and there is
+  # no version of that which is better than doing nothing.
+  # `Managers.ControlLevel` and `Traxxas.Motor` guard the same way.
+  def handle_info(_message, state), do: {:noreply, state}
 
   defp compute_throttle(state) do
     requested_throttle = state.raw_value |> D.div(@range)

--- a/vms/core/test/components/ovcs/ros_control/throttle_test.exs
+++ b/vms/core/test/components/ovcs/ros_control/throttle_test.exs
@@ -1,0 +1,120 @@
+defmodule VmsCore.Components.OVCS.ROSControl.ThrottleTest do
+  @moduledoc """
+  Tests for the ROS throttle expiry.
+
+  This is the failsafe that gates autonomous driving: without it a ROS
+  bridge that stops talking leaves the last commanded throttle applied
+  indefinitely, because `handle_frame` is the only thing that moves
+  `raw_value` while `emit/1` runs every 10 ms regardless.
+
+  Driven through `handle_info/2` against a stub state, the way
+  `VmsCore.Managers.GearTest` drives its manager: `init/1` subscribes
+  to Cantastic and enables a frame watcher, neither of which exists
+  under `mix test --no-start`, and none of them is what is under test.
+  """
+  use ExUnit.Case, async: true
+
+  alias Cantastic.{Frame, Signal}
+  alias Decimal, as: D
+  alias OvcsBus.Message
+  alias VmsCore.Components.OVCS.ROSControl.Throttle
+
+  @range 2 ** 31 - 1
+
+  defp stub_state(overrides \\ %{}) do
+    Map.merge(%{loop_timer: nil, raw_value: 0, requested_throttle: D.new(0)}, overrides)
+  end
+
+  defp frame(raw_value) do
+    {:handle_frame,
+     %Frame{
+       name: "ros_control1",
+       signals: %{
+         "throttle" => %Signal{name: "throttle", value: raw_value},
+         "steering" => %Signal{name: "steering", value: 0}
+       }
+     }}
+  end
+
+  # What the component would put on the bus on its next tick.
+  defp emitted(state) do
+    OvcsBus.subscribe("messages")
+    {:noreply, _state} = Throttle.handle_info(:loop, state)
+    assert_receive %Message{name: :requested_throttle, value: value, source: Throttle}
+    value
+  end
+
+  describe "a frame that stops arriving" do
+    test "zeroes the throttle" do
+      # Full throttle commanded, then the bridge goes quiet.
+      state = stub_state(%{raw_value: @range})
+      assert D.equal?(emitted(state), D.new(1))
+
+      {:noreply, expired} =
+        Throttle.handle_info({:handle_missing_frame, :ovcs, "ros_control1"}, state)
+
+      assert D.equal?(emitted(expired), D.new(0)),
+             "the last commanded throttle survived the bridge going away"
+    end
+
+    test "zeroes a braking request too, not just a driving one" do
+      # A negative request is regenerative braking. Holding *that*
+      # indefinitely is also wrong, so the expiry is symmetric.
+      state = stub_state(%{raw_value: -@range})
+      assert D.equal?(emitted(state), D.new(-1))
+
+      {:noreply, expired} =
+        Throttle.handle_info({:handle_missing_frame, :ovcs, "ros_control1"}, state)
+
+      assert D.equal?(emitted(expired), D.new(0))
+    end
+
+    test "the next frame to arrive restores control with no further ceremony" do
+      # Recovery needs no code of its own, which is worth pinning: a
+      # latch would have to be cleared somewhere, and a forgotten latch
+      # is a vehicle that never drives again after one dropped frame.
+      {:noreply, expired} =
+        Throttle.handle_info(
+          {:handle_missing_frame, :ovcs, "ros_control1"},
+          stub_state(%{raw_value: @range})
+        )
+
+      {:noreply, recovered} = Throttle.handle_info(frame(div(@range, 2)), expired)
+
+      assert_in_delta recovered.requested_throttle |> D.to_float(), 0.0, 1.0
+      assert_in_delta emitted(recovered) |> D.to_float(), 0.5, 0.001
+    end
+  end
+
+  describe "normal operation is unchanged" do
+    test "a commanded throttle is scaled onto 0..1" do
+      assert_in_delta emitted(stub_state(%{raw_value: @range})) |> D.to_float(), 1.0, 0.001
+      assert_in_delta emitted(stub_state(%{raw_value: 0})) |> D.to_float(), 0.0, 0.001
+    end
+
+    test "an arriving frame sets the raw value" do
+      {:noreply, state} = Throttle.handle_info(frame(1234), stub_state())
+      assert state.raw_value == 1234
+    end
+
+    test "an unexpected message is ignored rather than fatal" do
+      # The subscription is frame-scoped, so a missing-frame event for
+      # another frame should not reach this process in practice — but
+      # something eventually will: a late reply, a monitor going down.
+      # Without a catch-all clause that killed the throttle path, and a
+      # gap in throttle emission is worse than doing nothing. The other
+      # two clauses below are the messages that genuinely cannot be
+      # matched by the specific ones.
+      state = stub_state(%{raw_value: @range})
+
+      for message <- [
+            {:handle_missing_frame, :ovcs, "radio_control_channels0"},
+            {:DOWN, make_ref(), :process, self(), :normal},
+            :something_nobody_planned_for
+          ] do
+        assert {:noreply, ^state} = Throttle.handle_info(message, state),
+               "#{inspect(message)} was not ignored"
+      end
+    end
+  end
+end

--- a/vms/core/test/test_helper.exs
+++ b/vms/core/test/test_helper.exs
@@ -1,1 +1,17 @@
+# `mix test --no-start` keeps the application tree down, which is what
+# lets component callbacks be driven directly without Cantastic or a
+# CAN interface present. The pub/sub bus is the one exception: it is
+# not a peripheral, it is where components publish their results, so a
+# test asserting on what a component *emits* needs it up.
+#
+# `phoenix_pubsub` has to be started first — its PG2 adapter joins a
+# process group owned by that application, and without it the adapter
+# fails to start with a confusing "no process" on `Phoenix.PubSub`.
+#
+# Started here rather than per-module because the instance is
+# registered under the global name `OvcsBus`, so competing
+# `start_supervised!` calls from async modules would clash over it.
+{:ok, _apps} = Application.ensure_all_started(:phoenix_pubsub)
+{:ok, _pubsub} = Phoenix.PubSub.Supervisor.start_link(name: OvcsBus)
+
 ExUnit.start()


### PR DESCRIPTION
## The problem

`ROSControl.Throttle` moves `raw_value` only in `handle_frame`, and `emit/1` broadcasts `requested_throttle` every 10 ms regardless. On OVCS Mini that value goes straight to the ESC — the composer wires `requested_throttle_source: OVCS.ROSControl.Throttle` into `Traxxas.Throttle` with nothing in between.

So a ROS bridge that stops talking left the last commanded throttle applied indefinitely. **The vehicle keeps driving until something physical stops it.** Bridge BEAM crash, Zenoh partition, cut CAN link — all the same outcome.

This is a prerequisite for letting Nav2 drive anything, which is why it's on its own branch ahead of that work.

## The fix

The primitive already existed and was already proven in-tree. `Cantastic.ReceivedFrameWatcher` does missed-frame counting with hysteresis; `Orion.Bms2` and `GenericController` both use it; `ros_control1` already declares a frequency.

What was missing: `Receiver.subscribe/4` defaults to `%{errors: false}`, so the component was explicitly opted **out** of the missing-frame events it needed. It now subscribes with `%{errors: true}`, enables the watcher, and zeroes `raw_value` when the frame stops arriving.

Detection takes roughly **50 ms** — `frequency: 10` is a *period in milliseconds* per Cantastic's own README, so 100 Hz, plus 10 ms leeway and five consecutive late checks. About 10 cm of travel at 2 m/s.

Recovery needs no code: the next frame sets the value again. A test pins that, because a latch someone forgets to clear is a vehicle that never drives again after one dropped frame.

## Two decisions worth reviewing

**Only the throttle expires.** `ROSControl.Steering` holds its last value rather than centring. Removing propulsion is what makes the vehicle safe; snapping the wheels straight mid-corner is a new hazard rather than a mitigation, and it would be violent on OVCS1. It's also consistent with how a human takes over — `Managers.ControlLevel` switches the steering *source*, not its value. `ROSControl.Direction` is inert once throttle is zero.

**Added the catch-all `handle_info/2`** these components lacked, so a stray message can't kill the throttle path. `Managers.ControlLevel` and `Traxxas.Motor` already guard this way.

## Known gap

This covers the bridge going away, not **Nav2 dying behind a live bridge**. Cantastic emitters retransmit `state.data` on a timer, so in that case the CAN frames keep flowing with the last command and look perfectly healthy. That needs a bridge-side age check as well; `TwistStamped`'s timestamp (see the Nav2 PR) is what makes it possible.

## Verification

- 6 new tests pass; **4 of them fail against the original component**
- `mix test --no-start` in `vms/core`: 37 tests, 0 failures
- `mix credo --strict`: no issues
- `mix compile --warnings-as-errors`: clean

The test helper now starts the pub/sub bus, which `--no-start` leaves down, so a component's *emitted* value can be asserted rather than just its state.
