### PR TITLE
ci: lint the repo's Python, which nothing did

### DIFF
--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -6,12 +6,17 @@ name: ROS 2
 # as firmware not being built on pull requests, which cost us four
 # rounds of red CI before it was closed.
 #
-# Two levels, cheapest first:
+# Three levels, cheapest first:
 #
 #   * `compose-config` validates every compose file in seconds. It
 #     catches the mistakes that are both most likely and most annoying:
 #     a typo in a service, a `${VAR:?}` with nothing to satisfy it, an
 #     invalid profile.
+#   * `lint` runs ruff over the repo's own Python. Nothing else does:
+#     the launch files, the verification scripts and
+#     `decompress_stereo.py` — which runs on the *vehicle* — are only
+#     ever parsed when something starts them, so an undefined name in
+#     an error path shipped and waited.
 #   * `image` actually builds the shared ROS image. Every service on
 #     both sides of the fabric runs it (`foxglove_bridge` on the
 #     vehicle; `ros2` / `joy` / `calibrator` on the base station), so it
@@ -28,6 +33,7 @@ on:
   pull_request:
     paths:
       - 'ros2/**'
+      - 'ruff.toml'
       - '.github/workflows/ros2.yml'
   workflow_dispatch:
 
@@ -61,6 +67,23 @@ jobs:
           # a profile is otherwise skipped entirely and never validated.
           docker compose --profile standalone --profile calibration config -q \
             || docker compose config -q
+
+  lint:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Pinned: an unpinned linter turns somebody else's release into a
+      # red build on an unrelated pull request.
+      - name: Install ruff
+        run: pipx install ruff==0.16.6
+
+      # Configuration, including which paths are in scope, lives in
+      # `ruff.toml` at the repo root so a local run matches this one.
+      # `ruff format` is deliberately not checked — see that file.
+      - name: ruff check
+        run: ruff check --output-format=github .
 
   image:
     name: build the shared ROS image

--- a/ros2/vehicule/image/docker/decompress_stereo.py
+++ b/ros2/vehicule/image/docker/decompress_stereo.py
@@ -17,7 +17,7 @@ import numpy as np
 import rclpy
 from cv_bridge import CvBridge
 from rclpy.node import Node
-from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import CompressedImage, Image
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+# Python lint configuration, for `ruff check` in the ROS 2 workflow.
+#
+# Scoped to the ROS 2 stacks, which is where all of this repo's own
+# Python lives: two launch files, three test/probe scripts, and
+# `decompress_stereo.py`, which runs on the vehicle. The
+# `controllers/` tree also contains Python, but only vendored inside
+# `.pio/libdeps/`, and linting somebody else's library is noise.
+#
+# `ruff format` is deliberately *not* enforced. The only differences it
+# reports are joins of line breaks that were put in on purpose — a
+# format gate would rewrite deliberate layout to satisfy a column
+# count, which is churn rather than a defect caught. `ruff check` is
+# the half with signal: undefined names, unused imports, an `except`
+# that can never fire.
+include = ["ros2/**/*.py"]
+
+# Matches the Elixir formatter's default, which the rest of the tree is
+# written to, so one convention covers the repo.
+line-length = 98


### PR DESCRIPTION
## Nothing linted this repo's Python

The ROS 2 workflow validates compose files and builds the shared image, but nothing anywhere parses the Python until something runs it. Five files are in scope: two launch files, two verification scripts, and `decompress_stereo.py` — which runs **on the vehicle**. An undefined name in an error path would ship and wait.

`ruff check` closes that, pinned to `0.16.6` so a linter release doesn't turn up as red CI on an unrelated pull request.

## `ruff format` is deliberately not enforced

Every difference it reports is a join of a line break that was put in on purpose, so a format gate would rewrite deliberate layout to satisfy a column count — churn, not a defect caught. `ruff.toml` says so, and sets `line-length` to 98 to match the Elixir formatter default the rest of the tree is written to.

## One real finding

Unsorted imports in `decompress_stereo.py`, fixed in the same commit.

## Verification

- Five files in scope, clean
- A planted undefined name **is** caught
- `ruff check --output-format=github .` (exactly what CI runs) exits 0

Scope is `ros2/**`. `controllers/` has Python only vendored inside `.pio/libdeps/`, and linting somebody else's library is noise.
