### PR TITLE
feat(simulation): Nav2 driving the simulated Ackermann car

### DIFF
--- a/ros2/simulation/config/nav2.yaml
+++ b/ros2/simulation/config/nav2.yaml
@@ -1,0 +1,261 @@
+# Nav2 for the simulated OVCS Mini.
+#
+# ## Why there is no map here
+#
+# No map_server and no AMCL. Every frame is `odom`, and both costmaps use
+# a rolling window, so the car navigates relative to where it is rather
+# than inside a prior. That keeps this configuration honest about what it
+# proves — that Nav2's velocity output can drive an Ackermann vehicle —
+# without dragging in the map/SLAM decision, which is the largest open
+# piece of the real-vehicle track.
+#
+# It also avoids publishing a fake static `map -> odom` transform, which
+# is the usual shortcut and is worse: it looks like localisation.
+#
+# ## Ackermann is not the default
+#
+# `mppi::AckermannMotionModel` clamps yaw rate to `|vx| / min_turning_r`
+# inside the sampler, so infeasible arcs are never considered rather
+# than merely penalised.
+#
+# Leaving `motion_model` unset does not silently pick something wrong —
+# it is fatal, which is the good outcome. MPPI defaults the value to the
+# instance name `diff_drive`, and with no `FollowPath.diff_drive.plugin`
+# to resolve, controller_server refuses to configure. (The plugin XML's
+# description claims Omni is "the default model when no plugin is
+# explicitly configured"; that is not what the code does. Measured.)
+#
+# What *is* silent is naming a valid but wrong model. Substituting
+# `mppi::DiffDriveMotionModel` loads cleanly and removes the radius
+# constraint entirely — see `scripts/nav2_test.py`, which exists to
+# catch exactly that.
+#
+# min_turning_r comes from the vehicle: wheelbase / tan(steering_limit)
+# = 0.324 / tan(0.52) = 0.566 m, rounded up to 0.6 for margin.
+#
+# ## The planner is not kinematically aware
+#
+# There is no `nav2_smac_planner` in the Lyrical archive, so the global
+# plan comes from NavFn — a grid search that knows nothing about turning
+# radius. The plan can therefore contain corners this car cannot drive,
+# and MPPI has to make the best of it. Acceptable in an open workshop;
+# it is a real limitation in tight spaces and the reason a Hybrid-A*
+# planner would be worth building if navigation gets ambitious.
+
+controller_server:
+  ros__parameters:
+    use_sim_time: true
+    controller_frequency: 20.0
+    # The CAN command path runs at 100 Hz (`frequency: 10` in Cantastic
+    # is a period in milliseconds), so 20 Hz here is not the bottleneck.
+    min_x_velocity_threshold: 0.001
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.3
+    controller_plugins: ["FollowPath"]
+    progress_checker_plugins: ["progress_checker"]
+    goal_checker_plugins: ["goal_checker"]
+
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.25
+      movement_time_allowance: 15.0
+
+    goal_checker:
+      # `yaw_goal_tolerance` is deliberately huge. A car cannot rotate on
+      # the spot, so any final-heading requirement it cannot satisfy by
+      # driving leaves it stuck at the goal until the action times out.
+      # Position is what matters here; heading is whatever the approach
+      # produced.
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.30
+      yaw_goal_tolerance: 3.15
+      stateful: true
+
+    FollowPath:
+      plugin: "nav2_mppi_controller::MPPIController"
+      # `motion_model` names a plugin *instance*, and the class comes
+      # from `<instance>.plugin` — the same name-then-plugin pattern as
+      # the critics. Putting the class directly in `motion_model` fails
+      # with "No 'plugin' param for param ns!", which is a confusing way
+      # to be told you named a class where a namespace was wanted.
+      #
+      # The instance is called AckermannConstraints so `min_turning_r`
+      # keeps the parameter path it had when this was not a plugin.
+      motion_model: "AckermannConstraints"
+      AckermannConstraints:
+        plugin: "mppi::AckermannMotionModel"
+        min_turning_r: 0.6
+
+      time_steps: 40
+      model_dt: 0.05
+      batch_size: 1000
+      vx_std: 0.2
+      wz_std: 0.4
+      vx_max: 1.5
+      vx_min: -0.5
+      wz_max: 2.5
+      ax_max: 2.0
+      ax_min: -2.0
+      az_max: 3.0
+      iteration_count: 1
+      temperature: 0.3
+      gamma: 0.015
+      prune_distance: 2.0
+      transform_tolerance: 0.2
+      regenerate_noises: true
+
+      critics:
+        - "ConstraintCritic"
+        - "CostCritic"
+        - "GoalCritic"
+        - "GoalAngleCritic"
+        - "PathAlignCritic"
+        - "PathFollowCritic"
+        - "PathAngleCritic"
+        - "PreferForwardCritic"
+
+      ConstraintCritic: {enabled: true, cost_power: 1, cost_weight: 4.0}
+      GoalCritic: {enabled: true, cost_power: 1, cost_weight: 5.0, threshold_to_consider: 1.4}
+      GoalAngleCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 3.0
+        threshold_to_consider: 0.5
+      PreferForwardCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 5.0
+        threshold_to_consider: 0.5
+      CostCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 3.81
+        critical_cost: 300.0
+        consider_footprint: false
+        collision_cost: 1000000.0
+        near_goal_distance: 1.0
+      PathAlignCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 14.0
+        max_path_occupancy_ratio: 0.05
+        trajectory_point_step: 4
+        threshold_to_consider: 0.5
+        offset_from_furthest: 20
+      PathFollowCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 5.0
+        offset_from_furthest: 5
+        threshold_to_consider: 1.4
+      PathAngleCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 2.0
+        offset_from_furthest: 4
+        threshold_to_consider: 0.5
+        max_angle_to_furthest: 1.0
+
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      use_sim_time: true
+      global_frame: odom
+      robot_base_frame: base_link
+      update_frequency: 5.0
+      publish_frequency: 2.0
+      rolling_window: true
+      width: 6
+      height: 6
+      resolution: 0.05
+      # Half the diagonal of a 568 x 296 mm truck, plus a little.
+      robot_radius: 0.35
+      plugins: ["inflation_layer"]
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.55
+
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      use_sim_time: true
+      global_frame: odom
+      robot_base_frame: base_link
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      # Rolling, because without a map there is no fixed extent to
+      # anchor a static costmap to.
+      rolling_window: true
+      width: 30
+      height: 30
+      resolution: 0.1
+      robot_radius: 0.35
+      plugins: ["inflation_layer"]
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.55
+
+planner_server:
+  ros__parameters:
+    use_sim_time: true
+    expected_planner_frequency: 1.0
+    planner_plugins: ["GridBased"]
+    GridBased:
+      plugin: "nav2_navfn_planner::NavfnPlanner"
+      tolerance: 0.5
+      use_astar: true
+      allow_unknown: true
+
+bt_navigator:
+  ros__parameters:
+    use_sim_time: true
+    global_frame: odom
+    robot_base_frame: base_link
+    odom_topic: /odom
+    transform_tolerance: 0.2
+    # Both trees are overridden, because both stock trees put Spin in
+    # their recovery branch and this vehicle cannot execute one: the
+    # behaviour runs its full duration, produces no motion, and burns a
+    # RecoveryNode retry, so a single transient planning failure is
+    # enough to abort the action.
+    default_nav_to_pose_bt_xml: /opt/ovcs/config/nav2_ackermann_bt.xml
+    default_nav_through_poses_bt_xml: /opt/ovcs/config/nav2_ackermann_through_poses_bt.xml
+
+behavior_server:
+  ros__parameters:
+    use_sim_time: true
+    local_frame: odom
+    global_frame: odom
+    robot_base_frame: base_link
+    transform_tolerance: 0.2
+    local_costmap_topic: local_costmap/costmap_raw
+    local_footprint_topic: local_costmap/published_footprint
+    cycle_frequency: 10.0
+    # `spin` is loaded but never invoked. bt_navigator resolves every
+    # action server in *both* of its trees at activation, and the stock
+    # navigate_through_poses tree references Spin — without the server
+    # present it fails with "Action server spin not available" and the
+    # whole stack refuses to come up. Keeping the server costs nothing;
+    # what matters is that no tree here calls it. See the BT XMLs.
+    behavior_plugins: ["spin", "backup", "drive_on_heading", "wait"]
+    spin:
+      plugin: "nav2_behaviors::Spin"
+    backup:
+      plugin: "nav2_behaviors::BackUp"
+    drive_on_heading:
+      plugin: "nav2_behaviors::DriveOnHeading"
+    wait:
+      plugin: "nav2_behaviors::Wait"
+
+lifecycle_manager:
+  ros__parameters:
+    use_sim_time: true
+    autostart: true
+    bond_timeout: 0.0
+    node_names:
+      - controller_server
+      - planner_server
+      - behavior_server
+      - bt_navigator

--- a/ros2/simulation/config/nav2_ackermann_bt.xml
+++ b/ros2/simulation/config/nav2_ackermann_bt.xml
@@ -1,0 +1,44 @@
+<!--
+  NavigateToPose for a vehicle that cannot rotate on the spot.
+
+  This is Nav2's default nav-to-pose tree with one change: the recovery
+  fallback drops `Spin`. On an Ackermann vehicle a spin command produces
+  no motion at all — `AckermannSteering` needs forward speed to generate
+  yaw — so the behaviour runs its full duration, achieves nothing, and
+  the RecoveryNode burns a retry. With Spin first in the list, a single
+  transient planning failure is enough to abort the whole action.
+
+  What remains is `Wait` (for a costmap that will clear on its own, e.g.
+  a moving obstacle) and `BackUp` (which a car genuinely can do, and
+  which is the useful recovery when it has nosed into a dead end).
+
+  ClearCostmap services stay: they cost nothing and fix the common case
+  of a stale obstacle.
+-->
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <ControllerSelector selected_controller="{selected_controller}" default_controller="FollowPath" topic_name="controller_selector"/>
+        <PlannerSelector selected_planner="{selected_planner}" default_planner="GridBased" topic_name="planner_selector"/>
+        <RateController hz="1.0">
+          <RecoveryNode number_of_retries="1" name="ComputePathToPose">
+            <ComputePathToPose goal="{goal}" path="{path}" planner_id="{selected_planner}"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="{selected_controller}"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
+      </PipelineSequence>
+      <Sequence name="RecoveryActions">
+        <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+        <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+        <!-- No Spin: this vehicle cannot execute one. -->
+        <Wait wait_duration="2.0"/>
+        <BackUp backup_dist="0.30" backup_speed="0.15"/>
+      </Sequence>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/ros2/simulation/config/nav2_ackermann_through_poses_bt.xml
+++ b/ros2/simulation/config/nav2_ackermann_through_poses_bt.xml
@@ -1,0 +1,79 @@
+
+<!--
+  This Behavior Tree replans the global path periodically at 1 Hz through an array of poses continuously
+   and it also has recovery actions specific to planning / control as well as general system issues.
+-->
+<!--
+  NavigateThroughPoses for a vehicle that cannot rotate on the spot.
+
+  This is nav2_bt_navigator's stock
+  `navigate_through_poses_w_replanning_and_recovery.xml` with exactly
+  one line removed: the `Spin` recovery. On an Ackermann vehicle a spin
+  command produces no motion — `AckermannSteering` needs forward speed
+  to generate any yaw — so the behaviour runs its full duration,
+  achieves nothing, and consumes a recovery slot. Since the recoveries
+  sit in a RoundRobin, Spin is tried every other failure.
+
+  Kept deliberately close to upstream so a Nav2 bump is a readable
+  diff. The `spin` behaviour *server* is still loaded (see nav2.yaml) —
+  bt_navigator resolves action servers for both trees at activation.
+-->
+<root BTCPP_format="4" main_tree_to_execute="NavigateThroughPosesWReplanningAndRecovery">
+  <BehaviorTree ID="NavigateThroughPosesWReplanningAndRecovery">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <ProgressCheckerSelector selected_progress_checker="{selected_progress_checker}" default_progress_checker="progress_checker" topic_name="progress_checker_selector"/>
+        <GoalCheckerSelector selected_goal_checker="{selected_goal_checker}" default_goal_checker="general_goal_checker" topic_name="goal_checker_selector"/>
+        <PathHandlerSelector selected_path_handler="{selected_path_handler}" default_path_handler="PathHandler" topic_name="path_handler_selector"/>
+        <ControllerSelector selected_controller="{selected_controller}" default_controller="FollowPath" topic_name="controller_selector"/>
+        <PlannerSelector selected_planner="{selected_planner}" default_planner="GridBased" topic_name="planner_selector"/>
+        <RateController hz="0.333">
+          <RecoveryNode number_of_retries="1" name="ComputePathThroughPoses">
+            <Fallback name="FallbackComputePathToPose">
+              <ReactiveSequence name="CheckIfNewPathNeeded">
+                <Inverter>
+                  <GlobalUpdatedGoal/>
+                </Inverter>
+                <IsGoalNearby path="{path}" proximity_threshold="4.0" max_robot_pose_search_dist="1.5"/>
+                <TruncatePathLocal input_path="{path}" output_path="{remaining_path}" distance_forward="-1" distance_backward="0.0" />
+                <ValidatePath path="{remaining_path}"/>
+              </ReactiveSequence>
+              <ReactiveSequence>
+                <RemovePassedGoals input_goals="{goals}" output_goals="{goals}" radius="0.7" input_waypoint_statuses="{waypoint_statuses}" output_waypoint_statuses="{waypoint_statuses}"/>
+                <ComputePathThroughPoses goals="{goals}" path="{path}" planner_id="{selected_planner}" error_code_id="{compute_path_error_code}" error_msg="{compute_path_error_msg}"/>
+              </ReactiveSequence>
+            </Fallback>
+            <Sequence>
+              <WouldAPlannerRecoveryHelp error_code="{compute_path_error_code}"/>
+              <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
+            </Sequence>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="{selected_controller}" error_code_id="{follow_path_error_code}" error_msg="{follow_path_error_msg}" goal_checker_id="{selected_goal_checker}" progress_checker_id="{selected_progress_checker}" path_handler_id="{selected_path_handler}" tracking_feedback="{tracking_feedback}"/>
+          <Sequence>
+            <WouldAControllerRecoveryHelp error_code="{follow_path_error_code}"/>
+            <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+          </Sequence>
+        </RecoveryNode>
+      </PipelineSequence>
+      <Sequence>
+        <Fallback>
+          <WouldAControllerRecoveryHelp error_code="{follow_path_error_code}"/>
+          <WouldAPlannerRecoveryHelp error_code="{compute_path_error_code}"/>
+        </Fallback>
+        <ReactiveFallback name="RecoveryFallback">
+          <GoalUpdated/>
+          <RoundRobin name="RecoveryActions">
+            <Sequence name="ClearingActions">
+              <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+              <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+            </Sequence>
+            <Wait name="WaitRecovery" wait_duration="5.0" error_code_id="{wait_error_code}" error_msg="{wait_error_msg}"/>
+            <BackUp name="BackUpRecovery" backup_dist="0.30" backup_speed="0.15" error_code_id="{backup_error_code}" error_msg="{backup_error_msg}"/>
+          </RoundRobin>
+        </ReactiveFallback>
+      </Sequence>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/ros2/simulation/docker-compose.yml
+++ b/ros2/simulation/docker-compose.yml
@@ -67,6 +67,35 @@ services:
   # entry as a hard failure, which would make `up` fail on any machine
   # without one.
   #   docker compose --profile teleop up -d teleop
+  # Nav2, behind a profile so the plain `up -d` above stays a bare
+  # simulator. Its own image rather than packages in the shared one —
+  # see nav2/Dockerfile for why.
+  #
+  #   docker compose --profile nav2 up -d nav2
+  #
+  # It drives through /cmd_vel_nav (TwistStamped), which sim.launch.py
+  # bridges separately from the unstamped /cmd_vel that teleop uses.
+  nav2:
+    build:
+      context: .
+      dockerfile: nav2/Dockerfile
+    image: ovcs/nav2:lyrical
+    container_name: ovcs-nav2
+    profiles: ["nav2"]
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      RMW_IMPLEMENTATION: rmw_zenoh_cpp
+      ZENOH_SESSION_CONFIG_URI: /tmp/zenoh-session.json5
+      ZENOH_ENDPOINT_IP: ${ZENOH_ENDPOINT_IP:-127.0.0.1}
+    volumes:
+      - ./launch:/opt/ovcs/launch:ro
+      - ./config:/opt/ovcs/config:ro
+    command:
+      - bash
+      - -lc
+      - "ros2 launch /opt/ovcs/launch/nav2.launch.py"
+
   teleop:
     image: ovcs/sim:jetty
     container_name: ovcs-sim-teleop

--- a/ros2/simulation/launch/nav2.launch.py
+++ b/ros2/simulation/launch/nav2.launch.py
@@ -1,0 +1,79 @@
+"""Nav2 for the simulated OVCS Mini.
+
+Four lifecycle servers plus a manager to bring them up. Deliberately
+*not* `nav2_bringup`: there is no such package in the Lyrical archive,
+and its launch file would pull in map_server and AMCL, neither of which
+this configuration uses. See `config/nav2.yaml` for why there is no map.
+
+The velocity output needs saying out loud, because it is the one thing
+that silently does nothing if it is wrong. Nav2 1.5.1 publishes
+`geometry_msgs/TwistStamped`, not `Twist` —
+`nav2_util::TwistPublisher` reads `enable_stamped_cmd_vel` with a
+default of **true**, and `controller_server::publishVelocity` takes a
+`TwistStamped`. (The doc comment in `twist_publisher.hpp` still claims
+unstamped is the default; the code disagrees, and the code wins.)
+
+So the controller publishes to `/cmd_vel_nav`, and `sim.launch.py`
+bridges that as `TwistStamped` alongside the existing unstamped
+`/cmd_vel` that teleop and `drive_test.py` use. Two separate bridge
+nodes, both feeding the same Gazebo topic: one `parameter_bridge`
+cannot map two ROS topics onto one Gazebo topic, and one topic cannot
+carry two ROS types.
+
+That split mirrors the vehicle's own CAN protocol, where `0x2B0`
+carries `control_level: joy | auto`. Nothing arbitrates between them
+here, exactly as nothing arbitrates on OVCS Mini today — run one or
+the other.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+CONFIG = "/opt/ovcs/config/nav2.yaml"
+
+# Every server is a lifecycle node; the manager transitions them in this
+# order. bt_navigator last, because it needs the others' actions to
+# exist before it configures.
+SERVERS = [
+    ("nav2_controller", "controller_server"),
+    ("nav2_planner", "planner_server"),
+    ("nav2_behaviors", "behavior_server"),
+    ("nav2_bt_navigator", "bt_navigator"),
+]
+
+
+def generate_launch_description():
+    params = LaunchConfiguration("params_file")
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "params_file",
+                default_value=CONFIG,
+                description="Nav2 parameter file.",
+            ),
+            *[
+                Node(
+                    package=package,
+                    executable=executable,
+                    name=executable,
+                    output="screen",
+                    parameters=[params],
+                    # The controller's velocity goes to its own topic so
+                    # the unstamped teleop path keeps working — see the
+                    # module docstring.
+                    remappings=[("/cmd_vel", "/cmd_vel_nav")],
+                )
+                for package, executable in SERVERS
+            ],
+            Node(
+                package="nav2_lifecycle_manager",
+                executable="lifecycle_manager",
+                name="lifecycle_manager",
+                output="screen",
+                parameters=[params],
+            ),
+        ]
+    )

--- a/ros2/simulation/launch/sim.launch.py
+++ b/ros2/simulation/launch/sim.launch.py
@@ -70,6 +70,17 @@ CAMERA_TOPICS = ["/stereo/left/image_raw", "/stereo/right/image_raw"]
 # ignored tag would leave the car silently immobile.
 CMD_VEL_GZ = "/cmd_vel@geometry_msgs/msg/Twist]gz.msgs.Twist"
 
+# Nav2 publishes `TwistStamped`, not `Twist` —
+# `nav2_util::TwistPublisher` defaults `enable_stamped_cmd_vel` to
+# true. One topic cannot carry both types and one `parameter_bridge`
+# cannot map two ROS topics onto the same Gazebo topic, so the
+# autonomous command gets its own ROS topic and its own bridge node,
+# feeding the same `/model/<name>/cmd_vel` that teleop does.
+#
+# Without this, a Nav2 stack that looks entirely healthy moves nothing
+# at all: the type never matches, so the bridge simply never fires.
+NAV_CMD_VEL_GZ = "/cmd_vel@geometry_msgs/msg/TwistStamped]gz.msgs.Twist"
+
 
 def generate_launch_description():
     use_sim_time = {"use_sim_time": True}
@@ -153,10 +164,23 @@ def generate_launch_description():
             Node(
                 package="ros_gz_bridge",
                 executable="parameter_bridge",
+                name="parameter_bridge",
                 arguments=BRIDGE_TOPICS
                 + [["/model/", vehicle, CMD_VEL_GZ]],
                 parameters=[use_sim_time],
                 remappings=[(["/model/", vehicle, "/cmd_vel"], "/cmd_vel")],
+                output="screen",
+            ),
+            # Second bridge, stamped, for Nav2. Named explicitly because
+            # two nodes from the same executable would otherwise collide
+            # on the default node name.
+            Node(
+                package="ros_gz_bridge",
+                executable="parameter_bridge",
+                name="parameter_bridge_nav",
+                arguments=[["/model/", vehicle, NAV_CMD_VEL_GZ]],
+                parameters=[use_sim_time],
+                remappings=[(["/model/", vehicle, "/cmd_vel"], "/cmd_vel_nav")],
                 output="screen",
             ),
             # One image_bridge per camera; each offers raw and

--- a/ros2/simulation/nav2/Dockerfile
+++ b/ros2/simulation/nav2/Dockerfile
@@ -1,0 +1,34 @@
+# Nav2 for the simulated OVCS Mini.
+#
+# Derived from the shared base-station image rather than adding these
+# packages to it. Nav2 is several hundred megabytes, `ros2/vehicule/image`
+# is what balena ships to the RPis, and the car cannot use Nav2 until the
+# real-vehicle track lands (staleness failsafe, arbitration, odometry).
+# Promoting Nav2 into the shared image is a deliberate call to make then,
+# not a side effect of wanting it in the simulator now.
+#
+# It inherits the base image's ENTRYPOINT, so Zenoh and ROS init are the
+# same here as everywhere else on the fabric.
+FROM ovcs/ros2:lyrical
+
+# Individual servers rather than a metapackage: there is no
+# `ros-lyrical-navigation2` or `ros-lyrical-nav2-bringup` in the Lyrical
+# archive, and naming what we run keeps the image honest about it.
+#
+# nav2-behaviors is included even though the behaviour tree here does not
+# use Spin — bt_navigator's default plugin list loads the behavior server's
+# action clients at configure time.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ros-lyrical-nav2-controller \
+        ros-lyrical-nav2-mppi-controller \
+        ros-lyrical-nav2-planner \
+        ros-lyrical-nav2-navfn-planner \
+        ros-lyrical-nav2-bt-navigator \
+        ros-lyrical-nav2-behaviors \
+        ros-lyrical-nav2-behavior-tree \
+        ros-lyrical-nav2-lifecycle-manager \
+        ros-lyrical-nav2-costmap-2d \
+        ros-lyrical-nav2-simple-commander \
+        ros-lyrical-nav2-msgs \
+    && rm -rf /var/lib/apt/lists/*

--- a/vehicles/ovcs_mini/description/gazebo_ackermann.xacro
+++ b/vehicles/ovcs_mini/description/gazebo_ackermann.xacro
@@ -71,6 +71,14 @@
 
       <odom_topic>/odom</odom_topic>
       <tf_topic>/tf</tf_topic>
+      <!-- Without this the plugin derives the odometry frame from the
+           model name and publishes `ovcs_mini/odom`, which is not the
+           ROS convention and which Nav2 rejects outright: every costmap
+           logs `Invalid frame ID "odom" ... frame does not exist` and
+           never activates. `frame_id` was read out of the shipped
+           libgz-sim-ackermann-steering-system.so, like the rest of
+           these tags. -->
+      <frame_id>odom</frame_id>
       <child_frame_id>base_link</child_frame_id>
       <odom_publish_frequency>50</odom_publish_frequency>
     </plugin>


### PR DESCRIPTION
Nav2 1.5.1 driving the simulated OVCS Mini, in its own image behind a compose profile.

**Verified end to end:** a `NavigateToPose` goal 3 m ahead and 1 m across completes with status SUCCEEDED, and the car arrives inside the goal checker's tolerance. Worst observed `|wz| * R / |vx|` was 0.57, so the Ackermann limit genuinely holds.

```sh
mise run verify-nav2   # (the gate lives in the stacked PR)
# or
docker compose --profile nav2 up -d nav2
```

## Four things that each fail silently

Each fails silently. They're documented in `ros2/simulation/README.md` so the next person doesn't repeat them.

**Nav2 publishes `TwistStamped`, not `Twist`.** `nav2_util::TwistPublisher` reads `enable_stamped_cmd_vel` with a default of *true*, and `controller_server::publishVelocity` takes a `TwistStamped`. The doc comment in `twist_publisher.hpp` still claims unstamped is the default — the code disagrees, and the code wins. The existing bridge line is unstamped, so without a change nothing moves and nothing errors.

One topic can't carry both types and one `parameter_bridge` can't map two ROS topics onto one Gazebo topic, so Nav2 gets `/cmd_vel_nav` and its own bridge node, feeding the same Gazebo topic teleop and `drive_test.py` already feed. That split mirrors `0x2B0`'s `control_level: joy | auto` — and nothing arbitrates between them here, exactly as on the real Mini.

**MPPI has to be told the vehicle is Ackermann.** The Ackermann motion model clamps yaw rate to `|vx| / min_turning_r` *inside the sampler*, so infeasible arcs are never sampled rather than merely penalised. `min_turning_r` is 0.6 against the vehicle's measured 0.566 (`wheelbase / tan(steering_limit)`).

Note `motion_model` names a plugin **instance**, not a class — the class comes from `<instance>.plugin`. Naming the class directly fails with `No 'plugin' param for param ns!`. Leaving it unset is also fatal rather than silent, which is the good outcome: it defaults to the instance name `diff_drive`, which has no `.plugin` either.

**The simulated odometry frame was wrong.** The Ackermann plugin derives its odometry frame from the model name and was publishing `ovcs_mini/odom`. Nav2 rejects that outright — every costmap logs `Invalid frame ID "odom" ... frame does not exist` and never activates. `<frame_id>odom</frame_id>` fixes it at the source rather than teaching Nav2 a non-conventional frame name, which also leaves the model correct for `robot_localization` later.

**`Spin` aborts navigation on a car.** Both stock behaviour trees put it in their recovery branch, and an Ackermann vehicle can't execute one — `AckermannSteering` needs forward speed to generate yaw, so the behaviour runs its full duration, achieves nothing, and burns a recovery slot. Both trees are overridden to drop it, keeping `Wait` and `BackUp`. The `spin` *server* stays loaded: bt_navigator resolves action servers for **both** trees at activation and won't come up without it.

## No map, no AMCL

Every frame is `odom` and both costmaps roll. That's enough to prove the velocity path drives an Ackermann vehicle without taking on the map/SLAM decision, and it avoids a fake static `map -> odom`, which is the usual shortcut and worse because it *looks* like localisation.

## Known limitations

- There is no `nav2_smac_planner` in the Lyrical archive, so global plans come from NavFn and are **not kinematically feasible** — they can contain corners this car cannot drive, and MPPI has to carry that. Fine in an open workshop; a real constraint in tight spaces.
- `yaw_goal_tolerance` is deliberately ~π. A car cannot rotate to a commanded final heading, so requiring one leaves it stuck at the goal until the action times out.

## Image placement

Nav2 lives in a derived image (`FROM ovcs/ros2:lyrical`) rather than the shared one. `ros2/vehicule/image` is what balena ships to the RPis, Nav2 is several hundred megabytes, and the car cannot use it until the real-vehicle track lands (#44 and what follows). Promoting it into the shared image is a deliberate decision to make then.
