### PR TITLE
test(simulation): gate Nav2 on what it commands, not where it arrives

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -64,6 +64,10 @@ for lib in cantastic express_lrs msp_osd ovcs_control; do
 done
 """
 
+[tasks.verify-nav2]
+description = "Boot the simulator + Nav2, navigate to a goal and check the commands respect Ackermann limits"
+run = "cd ros2/simulation && ./verify_nav2.sh"
+
 [tasks.cli]
 description = "Build the ovcs CLI (Rust release binary → cli/ovcs)"
 run = "cd cli && cargo build --release && strip --strip-all target/release/ovcs && cp target/release/ovcs ovcs && chmod +x ovcs"

--- a/ros2/simulation/README.md
+++ b/ros2/simulation/README.md
@@ -227,6 +227,90 @@ to remap at the bridge if a consumer expects a bare `odom`.
 ros2 topic echo --no-daemon /odom
 ```
 
+## Navigating with Nav2
+
+```sh
+mise run verify-nav2            # up, navigate, check, down
+KEEP_UP=1 mise run verify-nav2  # leave the stack up to poke at
+
+# or by hand
+docker compose --profile nav2 up -d nav2
+docker logs -f ovcs-nav2
+```
+
+Nav2 1.5.1 in its own image (`nav2/Dockerfile`), behind a compose
+profile so a plain `up -d` stays a bare simulator. No map and no AMCL:
+every frame is `odom` and both costmaps roll. That is enough to prove
+the velocity path drives an Ackermann vehicle without taking on the
+map/SLAM question, and it avoids a fake static `map -> odom`, which is
+the usual shortcut and worse, because it looks like localisation.
+
+### Four things that each fail silently
+
+Every one of these cost a debugging cycle, so they are worth knowing
+before changing the configuration.
+
+- **Nav2 publishes `TwistStamped`.** `nav2_util::TwistPublisher`
+  defaults `enable_stamped_cmd_vel` to *true* — the doc comment in that
+  header still claims otherwise, and the code wins. The existing
+  `/cmd_vel` bridge is unstamped, so Nav2 gets its own topic
+  (`/cmd_vel_nav`) and its own bridge node feeding the same Gazebo
+  topic. Without that, a healthy-looking Nav2 moves nothing at all.
+- **`motion_model` names a plugin *instance*, not a class.** The class
+  comes from `<instance>.plugin`. Naming the class directly fails with
+  "No 'plugin' param for param ns!". Leaving `motion_model` unset is
+  fatal rather than silent, which is the good outcome: MPPI defaults it
+  to the instance name `diff_drive`, which has no `.plugin` param
+  either, so the controller refuses to configure.
+- **The odometry frame was `ovcs_mini/odom`.** The Ackermann plugin
+  derives it from the model name unless `<frame_id>` says otherwise, and
+  Nav2 rejects it: every costmap logs `Invalid frame ID "odom" ... frame
+  does not exist` and never activates.
+- **`Spin` aborts navigation on a car.** Both stock behaviour trees put
+  it in their recovery branch; an Ackermann vehicle produces no motion
+  at all from a spin command, so it runs its full duration and burns a
+  recovery slot. Both trees are overridden to drop it. The `spin`
+  *server* stays loaded, because bt_navigator resolves action servers
+  for both trees at activation and will not come up without it.
+
+### Reaching the goal proves almost nothing
+
+Gazebo's `AckermannSteering` quietly ignores commands it cannot
+execute, so a controller configured for a differential-drive robot
+still arrives — it just commands arcs the real steering could never
+cut. Measured: with `mppi::DiffDriveMotionModel` substituted in, the
+vehicle reached the tight goal *better* than the correct configuration
+did (0.30 m versus 0.53 m) while commanding a yaw rate 3.68x the
+kinematic limit.
+
+So `nav2_test.py` checks what was **commanded**, and uses two goals
+because no single goal can test both things:
+
+| goal | required arc | asserts |
+|---|---|---|
+| 3.0 m ahead, 1.0 m across | 5.00 m | arrival |
+| 0.8 m ahead, 1.4 m across | 0.93 m | the kinematic limits |
+
+An easy goal never approaches the radius limit — an unconstrained
+controller drives it at 0.74x, under the threshold, so the check
+passes. A tight goal does bite, but the *correct* configuration then
+needs to shuffle and may not arrive at all, so arrival is reported
+rather than asserted there. Each goal is asked only what it can
+answer.
+
+### Known limitations
+
+- There is no `nav2_smac_planner` in the Lyrical archive, so global
+  plans come from NavFn and are **not kinematically feasible** — they
+  can contain corners this car cannot drive, and MPPI has to carry
+  that. Fine in an open workshop; a real constraint in tight spaces.
+- `yaw_goal_tolerance` is deliberately ~pi. A car cannot rotate to a
+  commanded final heading, so requiring one leaves it stuck at the goal
+  until the action times out.
+- Nothing arbitrates between `/cmd_vel` and `/cmd_vel_nav`. Run teleop
+  or Nav2, not both — which mirrors OVCS Mini, where nothing arbitrates
+  between the radio and ROS either.
+
 ## Not here yet
 
 No IMU, so `/imu` is absent and anything downstream of it is untested

--- a/ros2/simulation/scripts/nav2_test.py
+++ b/ros2/simulation/scripts/nav2_test.py
@@ -1,0 +1,268 @@
+"""Drive the simulated vehicle with Nav2 and check what it commanded.
+
+Reaching the goal is the weakest of the three things checked here, and
+on its own it would pass with a configuration that is wrong in ways
+that matter on a real car.
+
+## What this actually guards
+
+1. **The goal is reached.** Proves the whole chain: bt_navigator ->
+   planner -> MPPI -> `/cmd_vel_nav` (TwistStamped) -> the stamped
+   bridge -> `AckermannSteering`. Any broken link here shows up as a
+   goal that never completes.
+
+2. **The turning radius is honoured.** For every commanded pair,
+   `|wz| <= |vx| / min_turning_r`. This is the assertion that catches
+   `motion_model` being unset or renamed, which silently reverts MPPI
+   to `mppi::OmniMotionModel` — holonomic, and happy to command
+   sideways and spin-in-place velocities the vehicle cannot produce.
+   The car still reaches the goal in simulation when that happens,
+   because Gazebo's plugin quietly ignores what it cannot do. On the
+   real vehicle it would be commanding arcs tighter than the steering
+   can cut.
+
+3. **No in-place rotation is commanded.** `vx` at zero with `wz`
+   nonzero is the one command an Ackermann vehicle can never execute.
+   It is what `Spin` recovery produces, and what a goal checker
+   demanding a final heading produces. Both abort navigation on a car.
+
+Check 2 is the reason this file exists. It is the only one that fails
+when the kinematic model is wrong, and the whole point of running Nav2
+against this vehicle rather than a differential-drive one.
+
+## Two goals, because one cannot test both things
+
+An easy goal never exercises the radius limit: a goal 3 m ahead and 1 m
+across needs a 5 m arc, and a completely unconstrained controller
+drives it at 0.72x the limit — under the threshold, so the check
+passes. Measured, not assumed.
+
+A tight goal does exercise it, but the *correctly* configured vehicle
+then struggles to arrive: at a required 0.93 m arc against a 0.57 m
+minimum, the Ackermann run needed 1317 commands and still timed out
+0.46 m short. Asserting arrival there would be a gate that fails on
+good configuration.
+
+So each goal is asked only what it can answer:
+
+  * **reach** — 3 m ahead, 1 m across. Arrival is required. The
+    kinematic checks run too, but they are not what this leg is for.
+  * **turn** — 0.8 m ahead, 1.4 m across, a required arc of 0.93 m
+    against a 0.57 m minimum. Arrival is **not** required: the point is
+    what gets commanded while trying, and a car legitimately needs to
+    shuffle. The kinematic checks are the whole assertion.
+
+## Tolerances
+
+Arrival allows 0.60 m against `nav2.yaml`'s `xy_goal_tolerance` of
+0.30. MPPI stops the moment the checker is satisfied, so asserting
+tighter than the thing under test is a flaky restatement of it.
+
+The radius check gets 10% of slack. MPPI clamps the control sequence it
+samples, so a published command should satisfy the constraint exactly —
+the Ackermann run peaks at exactly 1.00x. The margin covers rounding,
+and is nowhere near the 404x an unconstrained model reaches.
+
+`STANDSTILL_WZ` is 0.15 rad/s to separate two different things that
+both show up as yaw near zero speed. Momentary transients as the
+vehicle starts and stops reach 0.081; a genuine attempt to rotate on
+the spot reached 0.359. A handful of transient samples is allowed for
+the same reason.
+"""
+
+import math
+import sys
+import time
+
+import rclpy
+from geometry_msgs.msg import TwistStamped
+from nav2_msgs.action import NavigateToPose
+from nav_msgs.msg import Odometry
+from rclpy.action import ActionClient
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+
+# From vehicles/ovcs_mini/description/ovcs_mini.urdf.xacro:
+#   wheelbase / tan(steering_limit) = 0.324 / tan(0.52) = 0.566 m
+# nav2.yaml rounds that up to 0.6 for margin. Stated here independently
+# so a change to one has to be a change to both, in a diff someone reads.
+MIN_TURNING_RADIUS = 0.6
+RADIUS_SLACK = 1.10
+
+GOAL_TOLERANCE = 0.60
+GOAL_TIMEOUT = 90.0
+
+# Below this speed a commanded yaw rate is an in-place rotation, which
+# this vehicle cannot perform at all. See the tolerance note above for
+# where these two numbers come from.
+STANDSTILL_VX = 0.05
+STANDSTILL_WZ = 0.15
+# Start/stop transients produce a few of these legitimately.
+STANDSTILL_ALLOWANCE = 8
+
+# (label, dx, dy, arrival required). See "Two goals" above.
+GOALS = [
+    ("reach: 3.0 m ahead, 1.0 m across", 3.0, 1.0, True),
+    ("turn: 0.8 m ahead, 1.4 m across (0.93 m arc vs 0.57 m minimum)", 0.8, 1.4, False),
+]
+
+
+class Navigator(Node):
+    def __init__(self):
+        super().__init__("nav2_test")
+        self.set_parameters([Parameter("use_sim_time", value=True)])
+        self.client = ActionClient(self, NavigateToPose, "navigate_to_pose")
+        self.create_subscription(Odometry, "/odom", self.on_odom, 10)
+        # TwistStamped, not Twist. Subscribing with the wrong type here
+        # would report zero commands and pass every check vacuously.
+        self.create_subscription(TwistStamped, "/cmd_vel_nav", self.on_cmd, 30)
+        self.pose = None
+        self.commands = []
+
+    def on_odom(self, message):
+        position = message.pose.pose.position
+        self.pose = (position.x, position.y)
+
+    def on_cmd(self, message):
+        self.commands.append((message.twist.linear.x, message.twist.angular.z))
+
+    def settle(self, seconds):
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.05)
+
+
+def verdict(ok):
+    return "PASS " if ok else "FAIL "
+
+
+def check(failures, ok, label, detail):
+    print(f"  {verdict(ok)} {label}: {detail}")
+    if not ok:
+        failures.append(f"{label} — {detail}")
+
+
+def navigate(node, label, dx, dy, must_arrive, failures):
+    """Send one goal and check what was commanded on the way."""
+    node.commands = []
+    node.settle(1.0)
+    start = node.pose
+    target = (start[0] + dx, start[1] + dy)
+
+    goal = NavigateToPose.Goal()
+    goal.pose.header.frame_id = "odom"
+    goal.pose.header.stamp = node.get_clock().now().to_msg()
+    goal.pose.pose.position.x = target[0]
+    goal.pose.pose.position.y = target[1]
+    goal.pose.pose.orientation.w = 1.0
+
+    print()
+    print(label)
+
+    send = node.client.send_goal_async(goal)
+    rclpy.spin_until_future_complete(node, send, timeout_sec=20.0)
+    handle = send.result()
+
+    if handle is None or not handle.accepted:
+        check(failures, False, "goal accepted", "Nav2 rejected the goal")
+        return
+
+    result = handle.get_result_async()
+    deadline = time.time() + GOAL_TIMEOUT
+    while time.time() < deadline and not result.done():
+        rclpy.spin_once(node, timeout_sec=0.1)
+
+    status = result.result().status if result.done() else None
+    error = math.hypot(node.pose[0] - target[0], node.pose[1] - target[1])
+
+    if must_arrive:
+        check(
+            failures,
+            status == 4 and error <= GOAL_TOLERANCE,
+            "goal reached",
+            f"{error:.2f} m away, status {status if status else 'timed out'} "
+            f"(tolerance {GOAL_TOLERANCE:.2f})",
+        )
+    else:
+        # Reported, not asserted: a car legitimately needs to shuffle
+        # for an arc this tight, and demanding arrival here would fail
+        # on correct configuration. See the module docstring.
+        print(f"        (arrival not asserted: {error:.2f} m away, status {status})")
+
+    if not node.commands:
+        check(failures, False, "commands observed", "nothing published on /cmd_vel_nav")
+        return
+
+    # ── the turning radius ───────────────────────────────────────────
+    worst_ratio, worst = 0.0, (0.0, 0.0)
+    for vx, wz in node.commands:
+        allowed = abs(vx) / MIN_TURNING_RADIUS
+        ratio = abs(wz) / allowed if allowed > 1e-9 else (0.0 if abs(wz) < 1e-9 else math.inf)
+        if ratio > worst_ratio:
+            worst_ratio, worst = ratio, (vx, wz)
+
+    check(
+        failures,
+        worst_ratio <= RADIUS_SLACK,
+        "turning radius honoured",
+        f"worst |wz| was {worst_ratio:.2f}x the limit at "
+        f"vx={worst[0]:.3f}, wz={worst[1]:.3f} (R_min {MIN_TURNING_RADIUS} m)",
+    )
+
+    # ── in-place rotation ────────────────────────────────────────────
+    spins = [
+        (vx, wz)
+        for vx, wz in node.commands
+        if abs(vx) < STANDSTILL_VX and abs(wz) > STANDSTILL_WZ
+    ]
+    check(
+        failures,
+        len(spins) <= STANDSTILL_ALLOWANCE,
+        "no in-place rotation commanded",
+        f"{len(spins)} of {len(node.commands)} commands asked for yaw at a standstill "
+        f"(allowance {STANDSTILL_ALLOWANCE})"
+        + (f", worst wz={max(abs(w) for _, w in spins):.3f}" if spins else ""),
+    )
+
+    vxs = [c[0] for c in node.commands]
+    print(f"        vx range {min(vxs):+.3f} .. {max(vxs):+.3f} m/s")
+
+
+def main():
+    rclpy.init()
+    node = Navigator()
+    node.settle(3.0)
+
+    failures = []
+
+    if node.pose is None:
+        print("  FAIL  no odometry — is the simulator running?")
+        rclpy.shutdown()
+        return 1
+
+    if not node.client.wait_for_server(timeout_sec=30.0):
+        print("  FAIL  navigate_to_pose action server never appeared")
+        print("        Nav2 did not finish its lifecycle bringup.")
+        rclpy.shutdown()
+        return 1
+
+    print(f"Start pose: ({node.pose[0]:.2f}, {node.pose[1]:.2f})")
+
+    for label, dx, dy, must_arrive in GOALS:
+        navigate(node, label, dx, dy, must_arrive, failures)
+
+    rclpy.shutdown()
+
+    print()
+    if failures:
+        print(f"{len(failures)} failure(s):")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print("All Nav2 checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ros2/simulation/verify_nav2.sh
+++ b/ros2/simulation/verify_nav2.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Bring up the simulator and Nav2, send a goal, check what Nav2
+# commanded, tear it all down. One command, exit code says whether Nav2
+# can still drive an Ackermann vehicle.
+#
+# The third sibling of verify_perception.sh and verify_drivetrain.sh.
+# Slower than both, because it waits for Nav2's lifecycle bringup and
+# then for the vehicle to actually drive somewhere.
+#
+# What it is really for is the turning-radius check. Nav2 reaching a
+# goal in simulation proves less than it appears to: Gazebo's
+# AckermannSteering quietly ignores commands it cannot execute, so a
+# configuration that has reverted to the holonomic default still
+# arrives. See scripts/nav2_test.py.
+#
+# Usage:
+#   ./verify_nav2.sh              # up, navigate, check, down
+#   KEEP_UP=1 ./verify_nav2.sh    # leave it running to poke at
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+BASE="$REPO/ros2/base"
+
+KEEP_UP="${KEEP_UP:-0}"
+
+log()  { printf '\n\033[1;36m▸\033[0m %s\n' "$1"; }
+fail() { printf '\033[31m✗\033[0m %s\n' "$1" >&2; }
+
+cleanup() {
+  local code=$?
+  if [ "$KEEP_UP" = "1" ]; then
+    log "KEEP_UP=1 — leaving the stack running"
+    printf '  nav2 log: docker logs ovcs-nav2\n'
+    printf '  stop with: (cd %s && docker compose --profile nav2 down) && (cd %s && docker compose rm -sf ros2 zenohd)\n' \
+      "$HERE" "$BASE"
+    return $code
+  fi
+  log "Tearing down"
+  (cd "$HERE" && timeout 120 docker compose --profile nav2 down >/dev/null 2>&1)
+  (cd "$BASE" && timeout 120 docker compose rm -sf ros2 zenohd >/dev/null 2>&1)
+  return $code
+}
+trap cleanup EXIT
+
+# ── up ──────────────────────────────────────────────────────────────
+log "Starting the Zenoh router"
+(cd "$BASE" && ZENOH_ENDPOINT_IP=127.0.0.1 timeout 180 docker compose \
+  --profile standalone up -d zenohd ros2) || { fail "router/ros2 failed to start"; exit 1; }
+
+log "Starting the simulator"
+(cd "$HERE" && ZENOH_ENDPOINT_IP=127.0.0.1 timeout 300 docker compose up -d) \
+  || { fail "sim failed to start"; exit 1; }
+
+# ros2_control has to have claimed the joints and be publishing /odom
+# and /tf before Nav2's costmaps will accept a transform.
+sleep 20
+
+log "Starting Nav2"
+(cd "$HERE" && ZENOH_ENDPOINT_IP=127.0.0.1 timeout 300 docker compose --profile nav2 up -d nav2) \
+  || { fail "nav2 failed to start"; exit 1; }
+
+# Lifecycle bringup is sequential across five nodes and each waits on
+# a transform. A failure here is otherwise reported as "the action
+# server never appeared", which reads like a discovery problem.
+sleep 30
+if ! docker logs ovcs-nav2 2>&1 | grep -q "Managed nodes are active"; then
+  fail "Nav2 did not finish lifecycle bringup:"
+  docker logs ovcs-nav2 2>&1 | grep -iE "FATAL|ERROR" | tail -15 >&2
+  exit 1
+fi
+
+# ── check ───────────────────────────────────────────────────────────
+log "Navigating to a goal and checking what Nav2 commanded"
+# Run inside the nav2 container, not the base station's: the checks
+# need nav2_msgs for the NavigateToPose action, which only this image
+# has. Piped over stdin for the same reason as the other two verifiers
+# — scripts/ is mounted into the *sim* container.
+(timeout 300 docker exec -i ovcs-nav2 bash -lc \
+  'source /opt/ros/lyrical/setup.bash 2>/dev/null; exec python3 -') \
+  < "$HERE/scripts/nav2_test.py"
+result=$?
+
+if [ "$result" -ne 0 ]; then
+  fail "Nav2 checks failed — last of the nav2 log:"
+  docker logs ovcs-nav2 2>&1 | tail -20 >&2
+fi
+
+exit "$result"


### PR DESCRIPTION
> **Stacked on #47** — review that first; this targets `feat-nav2-sim`, not `main`.

`verify_nav2.sh` and `mise run verify-nav2`, the third sibling of the perception and drivetrain verifiers: bring up the simulator and Nav2, navigate, check, tear down.

## Reaching the goal proves almost nothing

Checking that the gate actually goes **red** is what showed how weak an arrival assertion is. Gazebo's `AckermannSteering` quietly ignores commands it cannot execute, so substituting `mppi::DiffDriveMotionModel` — a plausible regression, someone copying a differential-drive configuration — **reached the tight goal better than the correct setup did**, 0.30 m against 0.53 m, while commanding a yaw rate **3.68× the kinematic limit**.

A gate that only checked arrival would have called that a pass. And it is precisely the configuration that would command arcs the real steering cannot cut.

So the assertions are on what was published to `/cmd_vel_nav`:

- `|wz| <= |vx| / min_turning_r` for every command
- no yaw commanded at a standstill — the one thing an Ackermann vehicle can never do
- and arrival, on the goal where arrival is a fair question

## Two goals, because one cannot test both

Both halves were measured.

| goal | required arc | asserts | why |
|---|---|---|---|
| 3.0 m ahead, 1.0 m across | 5.00 m | arrival | never approaches the radius limit — the unconstrained model drives it at 0.74×, under any sane threshold |
| 0.8 m ahead, 1.4 m across | 0.93 m | the kinematic limits | bites hard, but the *correct* config then has to shuffle: it timed out 0.46 m short over 1317 commands |

Asserting arrival on the tight leg would be a gate that fails on good configuration, so that leg reports arrival without asserting it. Each goal is asked only what it can answer.

`STANDSTILL_WZ` is 0.15 rad/s because two different things both look like yaw near zero speed: start/stop transients reached 0.081, and a genuine attempt to rotate on the spot reached 0.359. A small allowance covers the transients.

## Verification

Both directions, from a cold stack:

- **Correct configuration:** green. Radius peaks at exactly 1.00× on the tight leg; zero standstill commands.
- **`DiffDriveMotionModel` substituted in:** red, naming the ratio and the offending command.
