### PR TITLE
test(simulation): gate the drivetrain, and catch the bug /odom hides

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -68,6 +68,10 @@ done
 description = "Boot the simulator + perception pipeline and check depth geometry against the world"
 run = "cd ros2/simulation && ./verify_perception.sh"
 
+[tasks.verify-drivetrain]
+description = "Boot the simulator, drive it and check the odometry against the model geometry"
+run = "cd ros2/simulation && ./verify_drivetrain.sh"
+
 [tasks.cli]
 description = "Build the ovcs CLI (Rust release binary → cli/ovcs)"
 run = "cd cli && cargo build --release && strip --strip-all target/release/ovcs && cp target/release/ovcs ovcs && chmod +x ovcs"

--- a/ros2/simulation/README.md
+++ b/ros2/simulation/README.md
@@ -79,9 +79,31 @@ turn 2.0 m/s, 0.5 rad/s  ->  R = 3.984 m   the above, at a second point
 ```
 
 The turning radius is the interesting one: it must equal `v / omega`,
-and it exercises wheelbase, track and kingpin width together. A model
-that drives convincingly can still report distance that is wrong by a
-constant factor, which is exactly the state the previous model was in.
+and it exercises wheelbase, track and kingpin width together.
+
+```sh
+mise run verify-drivetrain            # up, drive, check, down
+KEEP_UP=1 mise run verify-drivetrain  # leave the stack up to poke at
+```
+
+### /odom cannot catch a wrong wheel radius
+
+The obvious check — drive at 1 m/s and see whether `/odom` agrees — is
+worthless, and this was measured rather than reasoned about. Setting
+`<wheel_radius>` to 0.1 against the model's real 0.0548 leaves `/odom`
+reporting a flawless 1.000 m/s while the wheels turn at 10.0 rad/s, so
+the car is really crawling at `10.0 x 0.0548 = 0.548` m/s.
+
+The radius cancels inside `AckermannSteering`: the commanded speed is
+divided by it to get a joint velocity, and the joint velocity is
+multiplied by it again to get odometry. `/odom` is a command echo, and
+the vehicle *reports* correctly while **driving** wrong — the opposite
+of what `gazebo_ackermann.xacro` used to claim.
+
+So the wheel radius is checked against `/joint_states`, which reports
+the physical joint velocity. Ground speed is that velocity times the
+real wheel radius, and it must match what odometry claims. In a good
+run the wheels turn at 18.25 rad/s and `18.25 x 0.0548 = 1.000`.
 
 Two traps in *measuring* this, both of which caught the first version
 of `drive_test.py`:
@@ -96,9 +118,9 @@ of `drive_test.py`:
 
 ## Checking perception automatically
 
-`drive_test.py` checks drivetrain geometry against the model.
-`verify_perception.sh` does the same for perception, and unlike the
-drive test it **asserts and exits non-zero**, so it can run unattended:
+`verify_perception.sh` is the perception sibling of
+`verify_drivetrain.sh`. Both assert and exit non-zero, so both run
+unattended:
 
 ```sh
 mise run verify-perception                    # stereo only

--- a/ros2/simulation/scripts/drive_test.py
+++ b/ros2/simulation/scripts/drive_test.py
@@ -1,4 +1,4 @@
-"""Drive the simulated vehicle and measure what odometry reports.
+"""Drive the simulated vehicle and check what odometry reports.
 
 Two numbers matter, and both test geometry rather than motion:
 
@@ -8,15 +8,63 @@ Two numbers matter, and both test geometry rather than motion:
   * At 1.0 m/s and 0.5 rad/s the turning radius should be v/omega = 2 m,
     and it must be achievable within the steering limit:
     R_min = wheelbase / tan(steering_limit).
+
+It **asserts and exits non-zero**, like `perception_test.py`, so a
+model change that breaks the drivetrain geometry fails a command rather
+than needing someone to read three numbers and notice.
+
+## /odom alone cannot catch a wrong wheel radius
+
+`gazebo_ackermann.xacro` says a `wheel_radius` disagreeing with the
+model "produces a vehicle that drives correctly and *reports* the wrong
+distance". Under gz-sim 10's `AckermannSteering` that is not what
+happens, and it was measured here rather than assumed: with
+`<wheel_radius>` set to 0.1 against the model's real 0.0548, `/odom`
+reported a flawless 1.000 m/s while the wheels turned at 10.0 rad/s —
+so the car was actually crawling at 10.0 x 0.0548 = 0.548 m/s.
+
+The radius cancels: the plugin divides the commanded speed by it to get
+a joint velocity, then multiplies the joint velocity by it again to get
+odometry. `/odom` is a command echo, and a check that only reads
+`/odom` passes with the wheels off by any factor at all.
+
+So the wheel radius is checked against `/joint_states`, which is
+bridged already and reports the *physical* joint velocity. Ground speed
+is that velocity times the real wheel radius, and it must agree with
+what `/odom` claims. That comparison is the only thing here that would
+have caught the bug the previous model shipped with.
+
+## Tolerances
+
+Speed is commanded directly and the simulator tracks it exactly — 1.000
+and 2.000 m/s observed against 1.0 and 2.0 commanded — so 3% is
+generous.
+
+Radius is measured, not commanded: it comes out of the steering
+geometry via v/omega, and observed 2.032 m and 3.927 m against 2.0 and
+4.0 expected, i.e. under 2% off. 5% leaves room for tyre slip and for
+the settle window ending mid-ramp, while still catching the kind of
+error this exists for: the wheel radius that was once out by 2x, or a
+steering limit that silently cannot achieve the commanded arc.
+
+The straight leg additionally bounds yaw rate absolutely rather than as
+a fraction, since the commanded rate is zero. Observed +0.000 rad/s,
+so 0.02 is a measured bound.
+
+Ground speed against odometry gets 5%: it is a product of two measured
+quantities and the rear wheels slip a little in a corner, but the bug
+it exists for is a factor of nearly two.
 """
 
 import math
+import sys
 import time
 
 import rclpy
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
+from sensor_msgs.msg import JointState
 
 
 class Drive(Node):
@@ -38,6 +86,7 @@ class Drive(Node):
         super().__init__("drive_test")
         self.pub = self.create_publisher(Twist, "/cmd_vel", 10)
         self.create_subscription(Odometry, "/odom", self.on_odom, 10)
+        self.create_subscription(JointState, "/joint_states", self.on_joints, 10)
         self.reset()
 
     def reset(self):
@@ -46,6 +95,25 @@ class Drive(Node):
         self.previous = None
         self.t0 = None
         self.t1 = None
+        self.omega_sum = 0.0
+        self.omega_count = 0
+
+    def on_joints(self, message):
+        # The rear pair only. They are unsteered, so the mean of the
+        # two is the rear-axle centre speed exactly; a steered front
+        # wheel rolls at v/cos(delta), which reads 1.3% fast at the
+        # tightest arc here for no benefit.
+        rates = [
+            abs(velocity)
+            for name, velocity in zip(message.name, message.velocity or [])
+            if name in ("rear_left_wheel_joint", "rear_right_wheel_joint")
+        ]
+        if len(rates) == 2:
+            self.omega_sum += sum(rates) / 2
+            self.omega_count += 1
+
+    def mean_omega(self):
+        return self.omega_sum / self.omega_count if self.omega_count else None
 
     def on_odom(self, message):
         position = message.pose.pose.position
@@ -65,6 +133,32 @@ class Drive(Node):
         if self.t0 is None:
             self.t0 = stamp
         self.t1 = stamp
+
+
+# Speed is commanded and tracked exactly; radius is measured out of the
+# steering geometry. See the moduledoc for the observed values these
+# are drawn from.
+SPEED_TOLERANCE = 0.03
+RADIUS_TOLERANCE = 0.05
+# Absolute, not fractional: the commanded rate is zero, so there is
+# nothing to take a fraction of.
+STRAIGHT_YAW_LIMIT = 0.02
+GROUND_SPEED_TOLERANCE = 0.05
+# The vehicle's real wheels, from the Traxxas Slash 4x4 specification
+# and the `wheel_radius` property in
+# `vehicles/ovcs_mini/description/ovcs_mini.urdf.xacro`. Stated here
+# deliberately rather than read from the model: it is the independent
+# expectation the model is being checked against, so a model that
+# changed it would have to change this too, in a diff someone reads.
+WHEEL_RADIUS = 0.0548
+
+
+def within(measured, expected, fraction):
+    return abs(measured - expected) <= abs(expected) * fraction
+
+
+def verdict(ok):
+    return "PASS " if ok else "FAIL "
 
 
 def run(node, vx, wz, secs, label, settle=0.0):
@@ -92,21 +186,68 @@ def run(node, vx, wz, secs, label, settle=0.0):
         rclpy.spin_once(node, timeout_sec=0.02)
 
     distance, dyaw, dt = node.arc, node.yaw_total, (node.t1 or 0) - (node.t0 or 0)
+    omega = node.mean_omega()
     node.pub.publish(Twist())
     for _ in range(30):
         rclpy.spin_once(node, timeout_sec=0.02)
 
-    if dt <= 0:
-        print(f"{label}: NO ODOMETRY RECEIVED")
-        return
-
     print(f"{label}")
+
+    if dt <= 0:
+        print("    FAIL  no odometry received")
+        return ["no odometry received during: " + label]
+
+    speed = distance / dt
+    yaw_rate = dyaw / dt
     print(
         f"    sim {dt:.2f}s  path {distance:.3f} m  "
-        f"speed {distance / dt:.3f} m/s  yaw rate {dyaw / dt:+.3f} rad/s"
+        f"speed {speed:.3f} m/s  yaw rate {yaw_rate:+.3f} rad/s"
     )
-    if abs(dyaw) > 0.05:
-        print(f"    turning radius {distance / abs(dyaw):.3f} m")
+
+    failures = []
+    ok = within(speed, abs(vx), SPEED_TOLERANCE)
+    print(f"    {verdict(ok)} speed")
+    if not ok:
+        failures.append(f"speed {speed:.3f} m/s, commanded {abs(vx):.3f}")
+
+    if abs(wz) <= 1e-6:
+        # Commanded straight. Observed +0.000 rad/s, so this is a real
+        # bound rather than a guess: a steering offset or a left/right
+        # wheel-radius mismatch curves the path while every speed
+        # reading stays perfect.
+        ok = abs(yaw_rate) <= STRAIGHT_YAW_LIMIT
+        print(f"    {verdict(ok)} holds a straight line")
+        if not ok:
+            failures.append(f"yaw rate {yaw_rate:+.3f} rad/s while driving straight")
+    else:
+        # v/omega is the arc the command asks for. Comparing the
+        # measured radius to it tests the steering geometry, which no
+        # amount of correct speed would reveal.
+        expected = abs(vx) / abs(wz)
+        radius = distance / abs(dyaw) if abs(dyaw) > 0.05 else float("inf")
+        print(f"    turning radius {radius:.3f} m, expected {expected:.3f}")
+        ok = within(radius, expected, RADIUS_TOLERANCE)
+        print(f"    {verdict(ok)} turning radius")
+        if not ok:
+            failures.append(f"radius {radius:.3f} m, expected {expected:.3f}")
+
+    if omega is None:
+        print("    FAIL  no joint states received")
+        failures.append("no joint states received during: " + label)
+    else:
+        # The whole point of the file: physics against the plugin's own
+        # arithmetic. See the moduledoc — /odom cannot catch this alone.
+        ground = omega * WHEEL_RADIUS
+        print(f"    wheels {omega:.2f} rad/s -> ground speed {ground:.3f} m/s")
+        ok = within(ground, speed, GROUND_SPEED_TOLERANCE)
+        print(f"    {verdict(ok)} wheel radius agrees with odometry")
+        if not ok:
+            failures.append(
+                f"wheels turn at {omega:.2f} rad/s, i.e. {ground:.3f} m/s on "
+                f"{WHEEL_RADIUS} m wheels, but odometry claims {speed:.3f} m/s"
+            )
+
+    return failures
 
 
 def main():
@@ -116,13 +257,30 @@ def main():
     for _ in range(50):
         rclpy.spin_once(node, timeout_sec=0.02)
 
-    run(node, 1.0, 0.0, 7.0, "straight: 1.0 m/s, steady state  (expect 1.0 m/s)", settle=2.0)
-    run(node, 1.0, 0.5, 10.0, "turn: 1.0 m/s, 0.5 rad/s  (expect R = 2.0 m)", settle=3.0)
-    run(node, 2.0, 0.5, 10.0, "turn: 2.0 m/s, 0.5 rad/s  (expect R = 4.0 m)", settle=3.0)
+    failures = []
+    failures += run(
+        node, 1.0, 0.0, 7.0, "straight: 1.0 m/s, steady state  (expect 1.0 m/s)", settle=2.0
+    )
+    failures += run(
+        node, 1.0, 0.5, 10.0, "turn: 1.0 m/s, 0.5 rad/s  (expect R = 2.0 m)", settle=3.0
+    )
+    failures += run(
+        node, 2.0, 0.5, 10.0, "turn: 2.0 m/s, 0.5 rad/s  (expect R = 4.0 m)", settle=3.0
+    )
 
     node.destroy_node()
     rclpy.shutdown()
 
+    print()
+    if failures:
+        print(f"{len(failures)} failure(s):")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print("All drivetrain checks passed.")
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/ros2/simulation/verify_drivetrain.sh
+++ b/ros2/simulation/verify_drivetrain.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Bring up the simulator, drive it, check the odometry against the
+# geometry the model claims, tear it all down. One command, exit code
+# says whether the drivetrain is still correct.
+#
+# The sibling of verify_perception.sh, and much smaller, because this
+# loop never leaves ROS: sim → /odom → drive_test.py. No CAN, no BEAM,
+# no detector — so none of the preflight that verify_perception.sh
+# needs applies here.
+#
+# It exists for one bug class: the model's wheel radius was once wrong
+# by 2x, which reports 2x the distance travelled while looking
+# perfectly fine on screen. Nothing catches that but driving and
+# measuring.
+#
+# Usage:
+#   ./verify_drivetrain.sh              # up, check, down
+#   KEEP_UP=1 ./verify_drivetrain.sh    # leave it running to poke at
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+BASE="$REPO/ros2/base"
+
+KEEP_UP="${KEEP_UP:-0}"
+
+log()  { printf '\n\033[1;36m▸\033[0m %s\n' "$1"; }
+fail() { printf '\033[31m✗\033[0m %s\n' "$1" >&2; }
+
+cleanup() {
+  local code=$?
+  if [ "$KEEP_UP" = "1" ]; then
+    log "KEEP_UP=1 — leaving the stack running"
+    printf '  stop with: (cd %s && docker compose down) && (cd %s && docker compose rm -sf ros2 zenohd)\n' \
+      "$HERE" "$BASE"
+    return $code
+  fi
+  log "Tearing down"
+  (cd "$HERE" && timeout 120 docker compose down >/dev/null 2>&1)
+  (cd "$BASE" && timeout 120 docker compose rm -sf ros2 zenohd >/dev/null 2>&1)
+  return $code
+}
+trap cleanup EXIT
+
+# ── up ──────────────────────────────────────────────────────────────
+log "Starting the Zenoh router"
+(cd "$BASE" && ZENOH_ENDPOINT_IP=127.0.0.1 timeout 180 docker compose \
+  --profile standalone up -d zenohd ros2) || { fail "router/ros2 failed to start"; exit 1; }
+
+# empty.sdf would do — nothing here needs texture to correlate against,
+# unlike the perception check — but sharing workshop.sdf keeps the two
+# verifiers on one world, so a model change is exercised the same way
+# by both.
+log "Starting the simulator"
+(cd "$HERE" && timeout 300 docker compose up -d) || { fail "sim failed to start"; exit 1; }
+
+# ros2_control needs to have claimed the joints and started publishing
+# /odom before the first command means anything.
+sleep 20
+
+# ── check ───────────────────────────────────────────────────────────
+log "Driving the vehicle and measuring what odometry reports"
+# Piped over stdin rather than run from the mount, matching
+# verify_perception.sh: scripts/ is mounted into the *sim* container,
+# but the checks want the base station's rclpy so they talk to the
+# same Zenoh router everything else does.
+(cd "$BASE" && timeout 300 docker compose exec -T ros2 bash -lc \
+  'source /opt/ros/*/setup.bash 2>/dev/null; exec python3 -') \
+  < "$HERE/scripts/drive_test.py"
+result=$?
+
+[ "$result" -ne 0 ] && fail "drivetrain checks failed"
+
+exit "$result"

--- a/vehicles/ovcs_mini/description/gazebo_ackermann.xacro
+++ b/vehicles/ovcs_mini/description/gazebo_ackermann.xacro
@@ -10,11 +10,21 @@
   through `ros_gz_bridge` rather than by linking ROS into the plugin.
 
   Every geometry value below is read from the properties in
-  `ovcs_mini.urdf.xacro`, never retyped. The plugin computes odometry
-  from `wheel_radius` and `wheel_separation`, so a number that
-  disagrees with the model produces a vehicle that drives correctly
-  and *reports* the wrong distance — which is exactly the failure the
-  previous model shipped with, its 0.1 m wheels against a real 0.0548.
+  `ovcs_mini.urdf.xacro`, never retyped. That matters because of the
+  failure the previous model shipped with: 0.1 m wheels declared
+  against a real 0.0548.
+
+  The shape of that failure under gz-sim 10 is the opposite of what
+  one would expect, and was measured rather than assumed (see
+  `ros2/simulation/scripts/drive_test.py`). The radius cancels in the
+  plugin — commanded speed is divided by it to get a joint velocity,
+  and the joint velocity is multiplied by it again to get odometry —
+  so `/odom` reads a flawless 1.000 m/s while the car actually crawls
+  at 0.548. The vehicle *reports* correctly and **drives** wrong.
+
+  Which means `/odom` cannot catch it. `drive_test.py` compares the
+  physical joint velocity from `/joint_states` against what odometry
+  claims, and that comparison is what fails.
 
   Tag names here were read out of the shipped
   `libgz-sim-ackermann-steering-system.so` and the reference world


### PR DESCRIPTION
> **Stacked on #43** — this targets `feat-local-detector-backends`, which is still a draft pending the YOLOv8 licensing decision. The drivetrain work below is independent of that and could be rebased onto `main` to land first.

## /odom cannot catch a wrong wheel radius

`drive_test.py` printed three numbers for a human to read. Its perception sibling asserts and exits non-zero; this gives it the same teeth, plus `verify_drivetrain.sh` and `mise run verify-drivetrain`.

Checking that the gate actually goes red exposed the following. `gazebo_ackermann.xacro` claimed a `wheel_radius` disagreeing with the model *"produces a vehicle that drives correctly and reports the wrong distance."* Under gz-sim 10 it is the **reverse**.

Setting `<wheel_radius>` to 0.1 against the real 0.0548 left **every check passing**: `/odom` reported a flawless 1.000 m/s while the wheels turned at 10.0 rad/s, so the car was really crawling at 0.548 m/s. The radius cancels — the plugin divides the command by it to get a joint velocity and multiplies the joint velocity by it again to get odometry. `/odom` is a command echo, and any check reading only `/odom` passes with the wheels off by any factor at all.

The wheel radius is now checked against `/joint_states`, already bridged, which reports the physical joint velocity. Ground speed is that velocity times the real wheel radius and must agree with what odometry claims.

**Verified both ways:** red on the perturbed model, naming the factor; green on the real one, where 18.25 rad/s × 0.0548 = 1.000. The stale claim in the xacro comment is corrected rather than left to mislead the next person into writing the same vacuous check.

Tolerances are drawn from observed runs rather than guessed: speed comes out exact (1.000 / 2.000 m/s) so it gets 3%; turning radius is measured out of the steering geometry and lands within 2% so it gets 5%; the straight leg's yaw rate reads +0.000 so it gets an absolute 0.02 rad/s.

## Also in this stack: the DNN backend review

Two commits fixing the detector backend against the `RosBridge.Inference` contract. Four defects:

- **It blocked the caller.** Inference ran inline in `handle_call`, while the behaviour says "asynchronous and lossy" and `busy?/1` answered `false` unconditionally. The caller is `Detections`, which drives the stereo *depth* path from the same process — so an 800 ms CPU frame stalled depth for 800 ms, and a frame past the 10 s call timeout would have crashed `Detections`. Now a monitored child.
- **The decode cost 397 ms** at real yolov8n dimensions (84 × 8400) — `Nx.reduce_max`/`argmax` were 340 ms of it, because Nx's default backend is pure Elixir. `Evision.reduce/4` does the same 672k-element pass natively in 1.7 ms. **Now 6.0 ms, 66×.** The tests used a 2×2 input with 4 anchors and never went near it.
- **The class count was hardcoded** to 84, so any non-COCO model decoded as nothing at all, silently.
- **It never saw a grayscale frame** — found only by running it live. `left_rectified` is single-channel because SGBM needs grayscale, and OpenCV refuses with *"Number of input channels should be multiple of 3 but got 1"*. Both backends would have detected **nothing** the moment a real `yolov8n.onnx` was dropped in — the entire point of #43. Every test used a 3-channel fixture and passed.
