### PR TITLE
feat(ovcs_mini): default the Hailo detector to a permissively licensed model

### DIFF
--- a/docs/ros_perception_detection.md
+++ b/docs/ros_perception_detection.md
@@ -342,29 +342,75 @@ None of which is legal advice. If OVCS is going anywhere commercial
 with YOLOv8 specifically, that needs a real answer and an Ultralytics
 Enterprise licence is the direct route to one.
 
-### Permissively licensed alternatives
+### The Hailo path now defaults to a permissive model
 
-The durable fix is a detector that does not raise the question. All
-Apache-2.0 unless noted:
+**NanoDet-RepVGG**, Apache-2.0, from the same Hailo model zoo path.
+`OVCS_HAILO_MODEL=yolov8n` selects the original for anyone holding an
+Ultralytics licence.
 
-  * **YOLOX** (Megvii)
-  * **NanoDet**
-  * **DAMO-YOLO**
+It needs no code change, and that was checked rather than hoped for:
+
+  * The HEF carries **`HAILO_NET_FLOW_YOLOV8_NMS`** — the same in-graph
+    NMS net flow as `yolov8n.hef`, so the output is the same
+    `HAILO_NMS_BY_CLASS` layout `hailo_detect` already reads.
+  * `hailo_detect` derives the input size from
+    `input_vstream.get_info().shape` and the class count from
+    `nms_shape.number_of_classes`, so neither is assumed. Its only
+    hard requirement is a square 3-channel input.
+
+`yolox_tiny` is also in the zoo and also Apache-2.0, but it is **not**
+a drop-in: it carries `HAILO_NET_FLOW_YOLOX_NMS`, a different
+postprocess op. Worth knowing before reaching for the more obvious
+name.
+
+#### Still to confirm on the device
+
+Two things that need a Hailo-8 and cannot be checked from the HEF:
+
+  * That it loads and produces sensible detections. Failure here is
+    loud and harmless — `hailo_detect` logs the shape it got and exits,
+    `Inference.Hailo` answers `{:error, :unavailable}`, and stereo
+    depth is unaffected.
+  * The score threshold. 0.4 was measured against **yolov8n** at
+    480x270; it has not been re-taken for NanoDet, so treat it as a
+    starting point rather than a tuned value.
+
+### Other permissive options
+
+All Apache-2.0 unless noted. Those with a prebuilt HAILO8 HEF in model
+zoo v2.15.0 are marked, with sizes as served:
+
+  * **NanoDet-RepVGG** — in the zoo (6.7 MB). The default.
+  * **YOLOX** tiny / s-leaky — in the zoo (9.3 / 9.4 MB), different NMS op
+  * **DAMO-YOLO** tinynasL20_T — in the zoo (13.4 MB)
+  * **SSD-MobileNet v1/v2** — in the zoo (6.7 MB), weaker but long-supported
+  * **CenterNet** ResNet-v1-18, **EfficientDet-lite0** — in the zoo
   * **RT-DETR** — the original Baidu release, *not* the Ultralytics port
   * **RF-DETR** (Roboflow), **D-FINE**
-  * **SSD-MobileNet**, **EfficientDet** — weaker, but long-supported
   * torchvision's detectors (BSD-3)
 
 Avoid: YOLOv5/v8/v10/v11 (Ultralytics, AGPL-3.0), YOLOv6 and YOLOv7
-(GPL-3.0), YOLO-NAS (restrictive Deci licence).
+(GPL-3.0), YOLO-NAS (restrictive Deci licence). `yolov6n.hef` is in the
+zoo and is GPL-3.0, which is no better here than AGPL.
 
-A swap is not free. `hailo_detect` reads `HAILO_NMS_BY_CLASS` directly
-because YOLOv8's HEF runs NMS in-graph, and `Inference.Dnn.decode/6`
-expects an attribute-major `[1, 4 + classes, anchors]` output. A model
-without in-graph NMS needs suppression adding back on the Hailo path; a
-different output layout needs `decode/6` taught about it. Both are
-bounded, and `decode/6` already derives the class count from the shape
-rather than assuming 80.
+### The DNN path is still YOLOv8-shaped
+
+`Inference.Dnn.decode/6` expects an attribute-major
+`[1, 4 + classes, anchors]` output — YOLOv8's layout. It already
+derives the class count from the shape rather than assuming 80, so a
+different *size* of YOLOv8-style head works, but a genuinely different
+layout does not:
+
+  * YOLOX ONNX is anchor-major `[1, anchors, 5 + classes]` and carries
+    a separate objectness column that has to be multiplied into the
+    class score.
+  * NanoDet splits classification and box regression into separate
+    outputs and uses distribution-based box encoding.
+
+So teaching `decode/6` a second layout is the outstanding work for
+running a permissive model on the CPU/GPU backend. Bounded, and the
+tests for it already build their fixtures from raw float32 with the
+layout explicit, which is the right shape to extend.
 
 ### One thing fetching does not fix
 

--- a/scripts/models.tsv
+++ b/scripts/models.tsv
@@ -21,4 +21,14 @@
 # integrity check is a worse position than a committed one, not a
 # better one.
 
+# The default. NanoDet-RepVGG is Apache-2.0, so nothing about it
+# conflicts with this repository's MIT licence, and it needs no code
+# change: it carries the same in-graph NMS net flow as YOLOv8
+# (HAILO_NET_FLOW_YOLOV8_NMS), and `hailo_detect` derives the input
+# size and class count from the HEF at runtime.
+vehicles/ovcs_mini/priv/models/nanodet_repvgg.hef	001f01e35e5a568ddfc5ddd881efdb1fa689a4ee7a93250593702cf13ca98051	Apache-2.0 (NanoDet)	https://hailo-model-zoo.s3.eu-west-2.amazonaws.com/ModelZoo/Compiled/v2.15.0/hailo8/nanodet_repvgg.hef
+
+# Kept selectable for anyone who holds an Ultralytics licence, and
+# because its accuracy at this resolution is the measured baseline.
+# Set OVCS_HAILO_MODEL=yolov8n to use it.
 vehicles/ovcs_mini/priv/models/yolov8n.hef	4f250daa6ac16e030cfaaf164e1cbdfe83e5852c81ae6c339c94857dd2b7b8d2	AGPL-3.0 (Ultralytics YOLOv8) — commercial use requires an Ultralytics Enterprise licence	https://hailo-model-zoo.s3.eu-west-2.amazonaws.com/ModelZoo/Compiled/v2.15.0/hailo8/yolov8n.hef

--- a/vehicles/ovcs_mini/lib/ovcs_mini.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini.ex
@@ -277,13 +277,28 @@ defmodule OvcsMini do
       # furniture as animals. Measured at 480x270 the model still
       # scores real people at 0.74-0.91, so this leaves plenty of
       # headroom above the noise.
+      #
+      # That measurement is yolov8n's. It has *not* been re-taken for
+      # the NanoDet default, so treat 0.4 as a starting point there
+      # rather than a tuned value.
       # The stereo unit's own frame, since boxes are positioned in its
       # rectified pixels.
-      hef_path: Path.join(priv_models_dir(), "yolov8n.hef"),
+      hef_path: Path.join(priv_models_dir(), "#{hailo_model()}.hef"),
       score_threshold: 0.4,
       frame_id: "stereo_left"
     }
   end
+
+  # NanoDet-RepVGG by default, because it is Apache-2.0 and YOLOv8 is
+  # AGPL-3.0 — see the Model licensing section of
+  # docs/ros_perception_detection.md. The swap needs no code: both
+  # carry the same in-graph NMS net flow, and `hailo_detect` reads the
+  # input size and class count off the HEF rather than assuming them.
+  #
+  # `OVCS_HAILO_MODEL=yolov8n` selects the original for anyone holding
+  # an Ultralytics licence. Whatever is named here has to be in
+  # `scripts/models.tsv` so `mise run fetch-models` can fetch it.
+  defp hailo_model, do: System.get_env("OVCS_HAILO_MODEL", "nanodet_repvgg")
 
   defp priv_models_dir, do: :ovcs_mini |> :code.priv_dir() |> Path.join("models")
 

--- a/vehicles/ovcs_mini/priv/models/README.md
+++ b/vehicles/ovcs_mini/priv/models/README.md
@@ -26,7 +26,35 @@ before a first build. The licence is why it changed anyway.
 See `docs/ros_perception_detection.md` for the licensing note in full,
 including the permissively licensed models that are drop-in candidates.
 
-## yolov8n.hef
+## nanodet_repvgg.hef — the default
+
+NanoDet-RepVGG from the Hailo model zoo, **Apache-2.0**, which is why
+it is the default: nothing about it conflicts with this repository's
+MIT licence.
+
+It is a drop-in for the YOLOv8 model below, and that was verified from
+the HEF rather than assumed. It carries the same in-graph NMS net flow
+(`HAILO_NET_FLOW_YOLOV8_NMS`), so the output is the same
+`HAILO_NMS_BY_CLASS` layout `hailo_detect` already reads; and
+`hailo_detect` derives both the input size and the class count from the
+HEF at runtime, so neither is hardcoded to YOLOv8's.
+
+Two things still need a Hailo-8 to confirm: that it loads and detects
+sensibly, and the score threshold — 0.4 was measured against yolov8n,
+not this. Failure is loud and harmless: `hailo_detect` logs and exits,
+the backend answers `{:error, :unavailable}`, and stereo depth is
+unaffected.
+
+`yolox_tiny` is also Apache-2.0 and also in the zoo, but is **not** a
+drop-in — it uses `HAILO_NET_FLOW_YOLOX_NMS`, a different postprocess
+op.
+
+## yolov8n.hef — the AGPL alternative
+
+Selected with `OVCS_HAILO_MODEL=yolov8n`. Its accuracy at this
+resolution is the measured baseline, and it is the right choice for
+anyone holding an Ultralytics Enterprise licence.
+
 
 COCO YOLOv8-nano from the Hailo model zoo, compiled for **HAILO8**
 (the 26 TOPS AI HAT+, not the 13 TOPS Hailo-8L — a HEF is built for
@@ -49,10 +77,18 @@ its Port and answers `{:error, :unavailable}` when it is absent;
 stereo depth pipeline runs on regardless — losing detections is
 acceptable, taking depth down with it is not.
 
-## Swapping the model
+## Adding another
 
-`yolov8s.hef` from the same model zoo path is the accuracy/speed step
-up and has the identical input and output contract, so it is a
-drop-in — add it to `scripts/models.tsv` and change `:hef_path` in the
-vehicle's `:hailo_detector` opts. Anything with a different input size
-or without in-graph NMS is not.
+Add it to `scripts/models.tsv` — destination, sha256, licence, URL —
+and set `OVCS_HAILO_MODEL` to its basename.
+
+What has to hold: a **square 3-channel input** and **in-graph NMS
+producing `HAILO_NMS_BY_CLASS`**. Size and class count do not, since
+`hailo_detect` reads both off the HEF. `yolov8s.hef` from the same zoo
+path is the accuracy step up and satisfies all of it. A model with a
+different NMS net flow, or none, does not — see
+`docs/ros_perception_detection.md` for what a swap would cost then.
+
+Checking is cheap and needs no device:
+
+    strings <model>.hef | grep -oE 'HAILO_NET_FLOW_[A-Z0-9_]+'


### PR DESCRIPTION
> **Stacked on #50** — review that first; this targets `chore-unvendor-hailo-model`.

**NanoDet-RepVGG**, Apache-2.0, from the same Hailo model zoo path. `OVCS_HAILO_MODEL=yolov8n` selects the original for anyone holding an Ultralytics Enterprise licence.

#50 stopped *distributing* AGPL weights. This removes the question: a fresh checkout now fetches an Apache-2.0 model and never touches YOLOv8 unless asked to.

## It needs no code change

Read off the HEF:

- `nanodet_repvgg.hef` carries **`HAILO_NET_FLOW_YOLOV8_NMS`** — the *same* in-graph NMS net flow as `yolov8n.hef` — so its output is the same `HAILO_NMS_BY_CLASS` layout `hailo_detect` already reads.
- `hailo_detect` derives the input size from `input_vstream.get_info().shape` and the class count from `nms_shape.number_of_classes`. Neither is hardcoded to YOLOv8's, so NanoDet's smaller square input is fine.

## A useful negative result

`yolox_tiny` is also Apache-2.0 and also in the zoo, but is **not** a drop-in — it carries `HAILO_NET_FLOW_YOLOX_NMS`, a different postprocess op. The obvious name was the wrong one.

Checking costs nothing and needs no device, so it's now in the model README:

```sh
strings <model>.hef | grep -oE 'HAILO_NET_FLOW_[A-Z0-9_]+'
```

## Not verified

Two things need a Hailo-8, which was not available:

1. **That it loads and detects sensibly.** Failure here is loud and harmless — `hailo_detect` logs the shape it got and exits, `Inference.Hailo` answers `{:error, :unavailable}`, and stereo depth is unaffected. That's why defaulting to it before the device confirms it is defensible: the failure mode is "no detections plus a clear log line", not a misbehaving vehicle. It is the one outstanding item to check on a device.
2. **The score threshold.** 0.4 was measured against *yolov8n* at 480×270 and has not been re-taken. Flagged in the code comment as a starting point, because the original comment reads like a measurement and would otherwise be taken as one for the wrong model.

Defaulting back to `"yolov8n"` in `hailo_model/0` is a one-line change; the manifest carries both.

## The DNN path is unchanged

`Inference.Dnn.decode/6` expects YOLOv8's attribute-major `[1, 4 + classes, anchors]`. It derives the class count from the shape, so a different-sized YOLOv8-style head works — but NanoDet splits classification from box regression and uses distribution-based box encoding, and YOLOX is anchor-major with a separate objectness column.

Teaching `decode/6` a second layout is the outstanding work for the CPU/GPU backend. `docs/ros_perception_detection.md` records what each would need, and the decode tests already build fixtures from raw float32 with the layout explicit, which is the right shape to extend.

## Verification

- Both models fetch and pass their checksums
- `mix compile --warnings-as-errors` clean, `mix credo --strict` no issues, `mix format --check-formatted` clean
