### PR TITLE
test(simulation): restore the two gates that never reached main

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -72,6 +72,10 @@ run = "cd ros2/simulation && ./verify_perception.sh"
 description = "Boot the simulator, drive it and check the odometry against the model geometry"
 run = "cd ros2/simulation && ./verify_drivetrain.sh"
 
+[tasks.verify-nav2]
+description = "Boot the simulator + Nav2, navigate to a goal and check the commands respect Ackermann limits"
+run = "cd ros2/simulation && ./verify_nav2.sh"
+
 [tasks.fetch-models]
 description = "Download + verify the detection models (not vendored — see scripts/models.tsv for why)"
 run = "./scripts/fetch_models.sh"

--- a/mise.toml
+++ b/mise.toml
@@ -68,6 +68,10 @@ done
 description = "Boot the simulator + perception pipeline and check depth geometry against the world"
 run = "cd ros2/simulation && ./verify_perception.sh"
 
+[tasks.verify-drivetrain]
+description = "Boot the simulator, drive it and check the odometry against the model geometry"
+run = "cd ros2/simulation && ./verify_drivetrain.sh"
+
 [tasks.fetch-models]
 description = "Download + verify the detection models (not vendored — see scripts/models.tsv for why)"
 run = "./scripts/fetch_models.sh"

--- a/ros2/simulation/README.md
+++ b/ros2/simulation/README.md
@@ -79,9 +79,31 @@ turn 2.0 m/s, 0.5 rad/s  ->  R = 3.984 m   the above, at a second point
 ```
 
 The turning radius is the interesting one: it must equal `v / omega`,
-and it exercises wheelbase, track and kingpin width together. A model
-that drives convincingly can still report distance that is wrong by a
-constant factor, which is exactly the state the previous model was in.
+and it exercises wheelbase, track and kingpin width together.
+
+```sh
+mise run verify-drivetrain            # up, drive, check, down
+KEEP_UP=1 mise run verify-drivetrain  # leave the stack up to poke at
+```
+
+### /odom cannot catch a wrong wheel radius
+
+The obvious check — drive at 1 m/s and see whether `/odom` agrees — is
+worthless, and this was measured rather than reasoned about. Setting
+`<wheel_radius>` to 0.1 against the model's real 0.0548 leaves `/odom`
+reporting a flawless 1.000 m/s while the wheels turn at 10.0 rad/s, so
+the car is really crawling at `10.0 x 0.0548 = 0.548` m/s.
+
+The radius cancels inside `AckermannSteering`: the commanded speed is
+divided by it to get a joint velocity, and the joint velocity is
+multiplied by it again to get odometry. `/odom` is a command echo, and
+the vehicle *reports* correctly while **driving** wrong — the opposite
+of what `gazebo_ackermann.xacro` used to claim.
+
+So the wheel radius is checked against `/joint_states`, which reports
+the physical joint velocity. Ground speed is that velocity times the
+real wheel radius, and it must match what odometry claims. In a good
+run the wheels turn at 18.25 rad/s and `18.25 x 0.0548 = 1.000`.
 
 Two traps in *measuring* this, both of which caught the first version
 of `drive_test.py`:
@@ -96,9 +118,9 @@ of `drive_test.py`:
 
 ## Checking perception automatically
 
-`drive_test.py` checks drivetrain geometry against the model.
-`verify_perception.sh` does the same for perception, and unlike the
-drive test it **asserts and exits non-zero**, so it can run unattended:
+`verify_perception.sh` is the perception sibling of
+`verify_drivetrain.sh`. Both assert and exit non-zero, so both run
+unattended:
 
 ```sh
 mise run verify-perception                    # stereo only

--- a/ros2/simulation/README.md
+++ b/ros2/simulation/README.md
@@ -326,6 +326,90 @@ to remap at the bridge if a consumer expects a bare `odom`.
 ros2 topic echo --no-daemon /odom
 ```
 
+## Navigating with Nav2
+
+```sh
+mise run verify-nav2            # up, navigate, check, down
+KEEP_UP=1 mise run verify-nav2  # leave the stack up to poke at
+
+# or by hand
+docker compose --profile nav2 up -d nav2
+docker logs -f ovcs-nav2
+```
+
+Nav2 1.5.1 in its own image (`nav2/Dockerfile`), behind a compose
+profile so a plain `up -d` stays a bare simulator. No map and no AMCL:
+every frame is `odom` and both costmaps roll. That is enough to prove
+the velocity path drives an Ackermann vehicle without taking on the
+map/SLAM question, and it avoids a fake static `map -> odom`, which is
+the usual shortcut and worse, because it looks like localisation.
+
+### Four things that each fail silently
+
+Every one of these cost a debugging cycle, so they are worth knowing
+before changing the configuration.
+
+- **Nav2 publishes `TwistStamped`.** `nav2_util::TwistPublisher`
+  defaults `enable_stamped_cmd_vel` to *true* — the doc comment in that
+  header still claims otherwise, and the code wins. The existing
+  `/cmd_vel` bridge is unstamped, so Nav2 gets its own topic
+  (`/cmd_vel_nav`) and its own bridge node feeding the same Gazebo
+  topic. Without that, a healthy-looking Nav2 moves nothing at all.
+- **`motion_model` names a plugin *instance*, not a class.** The class
+  comes from `<instance>.plugin`. Naming the class directly fails with
+  "No 'plugin' param for param ns!". Leaving `motion_model` unset is
+  fatal rather than silent, which is the good outcome: MPPI defaults it
+  to the instance name `diff_drive`, which has no `.plugin` param
+  either, so the controller refuses to configure.
+- **The odometry frame was `ovcs_mini/odom`.** The Ackermann plugin
+  derives it from the model name unless `<frame_id>` says otherwise, and
+  Nav2 rejects it: every costmap logs `Invalid frame ID "odom" ... frame
+  does not exist` and never activates.
+- **`Spin` aborts navigation on a car.** Both stock behaviour trees put
+  it in their recovery branch; an Ackermann vehicle produces no motion
+  at all from a spin command, so it runs its full duration and burns a
+  recovery slot. Both trees are overridden to drop it. The `spin`
+  *server* stays loaded, because bt_navigator resolves action servers
+  for both trees at activation and will not come up without it.
+
+### Reaching the goal proves almost nothing
+
+Gazebo's `AckermannSteering` quietly ignores commands it cannot
+execute, so a controller configured for a differential-drive robot
+still arrives — it just commands arcs the real steering could never
+cut. Measured: with `mppi::DiffDriveMotionModel` substituted in, the
+vehicle reached the tight goal *better* than the correct configuration
+did (0.30 m versus 0.53 m) while commanding a yaw rate 3.68x the
+kinematic limit.
+
+So `nav2_test.py` checks what was **commanded**, and uses two goals
+because no single goal can test both things:
+
+| goal | required arc | asserts |
+|---|---|---|
+| 3.0 m ahead, 1.0 m across | 5.00 m | arrival |
+| 0.8 m ahead, 1.4 m across | 0.93 m | the kinematic limits |
+
+An easy goal never approaches the radius limit — an unconstrained
+controller drives it at 0.74x, under the threshold, so the check
+passes. A tight goal does bite, but the *correct* configuration then
+needs to shuffle and may not arrive at all, so arrival is reported
+rather than asserted there. Each goal is asked only what it can
+answer.
+
+### Known limitations
+
+- There is no `nav2_smac_planner` in the Lyrical archive, so global
+  plans come from NavFn and are **not kinematically feasible** — they
+  can contain corners this car cannot drive, and MPPI has to carry
+  that. Fine in an open workshop; a real constraint in tight spaces.
+- `yaw_goal_tolerance` is deliberately ~pi. A car cannot rotate to a
+  commanded final heading, so requiring one leaves it stuck at the goal
+  until the action times out.
+- Nothing arbitrates between `/cmd_vel` and `/cmd_vel_nav`. Run teleop
+  or Nav2, not both — which mirrors OVCS Mini, where nothing arbitrates
+  between the radio and ROS either.
+
 ## Not here yet
 
 No IMU, so `/imu` is absent and anything downstream of it is untested

--- a/ros2/simulation/scripts/drive_test.py
+++ b/ros2/simulation/scripts/drive_test.py
@@ -1,4 +1,4 @@
-"""Drive the simulated vehicle and measure what odometry reports.
+"""Drive the simulated vehicle and check what odometry reports.
 
 Two numbers matter, and both test geometry rather than motion:
 
@@ -8,15 +8,63 @@ Two numbers matter, and both test geometry rather than motion:
   * At 1.0 m/s and 0.5 rad/s the turning radius should be v/omega = 2 m,
     and it must be achievable within the steering limit:
     R_min = wheelbase / tan(steering_limit).
+
+It **asserts and exits non-zero**, like `perception_test.py`, so a
+model change that breaks the drivetrain geometry fails a command rather
+than needing someone to read three numbers and notice.
+
+## /odom alone cannot catch a wrong wheel radius
+
+`gazebo_ackermann.xacro` says a `wheel_radius` disagreeing with the
+model "produces a vehicle that drives correctly and *reports* the wrong
+distance". Under gz-sim 10's `AckermannSteering` that is not what
+happens, and it was measured here rather than assumed: with
+`<wheel_radius>` set to 0.1 against the model's real 0.0548, `/odom`
+reported a flawless 1.000 m/s while the wheels turned at 10.0 rad/s —
+so the car was actually crawling at 10.0 x 0.0548 = 0.548 m/s.
+
+The radius cancels: the plugin divides the commanded speed by it to get
+a joint velocity, then multiplies the joint velocity by it again to get
+odometry. `/odom` is a command echo, and a check that only reads
+`/odom` passes with the wheels off by any factor at all.
+
+So the wheel radius is checked against `/joint_states`, which is
+bridged already and reports the *physical* joint velocity. Ground speed
+is that velocity times the real wheel radius, and it must agree with
+what `/odom` claims. That comparison is the only thing here that would
+have caught the bug the previous model shipped with.
+
+## Tolerances
+
+Speed is commanded directly and the simulator tracks it exactly — 1.000
+and 2.000 m/s observed against 1.0 and 2.0 commanded — so 3% is
+generous.
+
+Radius is measured, not commanded: it comes out of the steering
+geometry via v/omega, and observed 2.032 m and 3.927 m against 2.0 and
+4.0 expected, i.e. under 2% off. 5% leaves room for tyre slip and for
+the settle window ending mid-ramp, while still catching the kind of
+error this exists for: the wheel radius that was once out by 2x, or a
+steering limit that silently cannot achieve the commanded arc.
+
+The straight leg additionally bounds yaw rate absolutely rather than as
+a fraction, since the commanded rate is zero. Observed +0.000 rad/s,
+so 0.02 is a measured bound.
+
+Ground speed against odometry gets 5%: it is a product of two measured
+quantities and the rear wheels slip a little in a corner, but the bug
+it exists for is a factor of nearly two.
 """
 
 import math
+import sys
 import time
 
 import rclpy
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Odometry
 from rclpy.node import Node
+from sensor_msgs.msg import JointState
 
 
 class Drive(Node):
@@ -38,6 +86,7 @@ class Drive(Node):
         super().__init__("drive_test")
         self.pub = self.create_publisher(Twist, "/cmd_vel", 10)
         self.create_subscription(Odometry, "/odom", self.on_odom, 10)
+        self.create_subscription(JointState, "/joint_states", self.on_joints, 10)
         self.reset()
 
     def reset(self):
@@ -46,6 +95,25 @@ class Drive(Node):
         self.previous = None
         self.t0 = None
         self.t1 = None
+        self.omega_sum = 0.0
+        self.omega_count = 0
+
+    def on_joints(self, message):
+        # The rear pair only. They are unsteered, so the mean of the
+        # two is the rear-axle centre speed exactly; a steered front
+        # wheel rolls at v/cos(delta), which reads 1.3% fast at the
+        # tightest arc here for no benefit.
+        rates = [
+            abs(velocity)
+            for name, velocity in zip(message.name, message.velocity or [])
+            if name in ("rear_left_wheel_joint", "rear_right_wheel_joint")
+        ]
+        if len(rates) == 2:
+            self.omega_sum += sum(rates) / 2
+            self.omega_count += 1
+
+    def mean_omega(self):
+        return self.omega_sum / self.omega_count if self.omega_count else None
 
     def on_odom(self, message):
         position = message.pose.pose.position
@@ -65,6 +133,32 @@ class Drive(Node):
         if self.t0 is None:
             self.t0 = stamp
         self.t1 = stamp
+
+
+# Speed is commanded and tracked exactly; radius is measured out of the
+# steering geometry. See the moduledoc for the observed values these
+# are drawn from.
+SPEED_TOLERANCE = 0.03
+RADIUS_TOLERANCE = 0.05
+# Absolute, not fractional: the commanded rate is zero, so there is
+# nothing to take a fraction of.
+STRAIGHT_YAW_LIMIT = 0.02
+GROUND_SPEED_TOLERANCE = 0.05
+# The vehicle's real wheels, from the Traxxas Slash 4x4 specification
+# and the `wheel_radius` property in
+# `vehicles/ovcs_mini/description/ovcs_mini.urdf.xacro`. Stated here
+# deliberately rather than read from the model: it is the independent
+# expectation the model is being checked against, so a model that
+# changed it would have to change this too, in a diff someone reads.
+WHEEL_RADIUS = 0.0548
+
+
+def within(measured, expected, fraction):
+    return abs(measured - expected) <= abs(expected) * fraction
+
+
+def verdict(ok):
+    return "PASS " if ok else "FAIL "
 
 
 def run(node, vx, wz, secs, label, settle=0.0):
@@ -92,21 +186,68 @@ def run(node, vx, wz, secs, label, settle=0.0):
         rclpy.spin_once(node, timeout_sec=0.02)
 
     distance, dyaw, dt = node.arc, node.yaw_total, (node.t1 or 0) - (node.t0 or 0)
+    omega = node.mean_omega()
     node.pub.publish(Twist())
     for _ in range(30):
         rclpy.spin_once(node, timeout_sec=0.02)
 
-    if dt <= 0:
-        print(f"{label}: NO ODOMETRY RECEIVED")
-        return
-
     print(f"{label}")
+
+    if dt <= 0:
+        print("    FAIL  no odometry received")
+        return ["no odometry received during: " + label]
+
+    speed = distance / dt
+    yaw_rate = dyaw / dt
     print(
         f"    sim {dt:.2f}s  path {distance:.3f} m  "
-        f"speed {distance / dt:.3f} m/s  yaw rate {dyaw / dt:+.3f} rad/s"
+        f"speed {speed:.3f} m/s  yaw rate {yaw_rate:+.3f} rad/s"
     )
-    if abs(dyaw) > 0.05:
-        print(f"    turning radius {distance / abs(dyaw):.3f} m")
+
+    failures = []
+    ok = within(speed, abs(vx), SPEED_TOLERANCE)
+    print(f"    {verdict(ok)} speed")
+    if not ok:
+        failures.append(f"speed {speed:.3f} m/s, commanded {abs(vx):.3f}")
+
+    if abs(wz) <= 1e-6:
+        # Commanded straight. Observed +0.000 rad/s, so this is a real
+        # bound rather than a guess: a steering offset or a left/right
+        # wheel-radius mismatch curves the path while every speed
+        # reading stays perfect.
+        ok = abs(yaw_rate) <= STRAIGHT_YAW_LIMIT
+        print(f"    {verdict(ok)} holds a straight line")
+        if not ok:
+            failures.append(f"yaw rate {yaw_rate:+.3f} rad/s while driving straight")
+    else:
+        # v/omega is the arc the command asks for. Comparing the
+        # measured radius to it tests the steering geometry, which no
+        # amount of correct speed would reveal.
+        expected = abs(vx) / abs(wz)
+        radius = distance / abs(dyaw) if abs(dyaw) > 0.05 else float("inf")
+        print(f"    turning radius {radius:.3f} m, expected {expected:.3f}")
+        ok = within(radius, expected, RADIUS_TOLERANCE)
+        print(f"    {verdict(ok)} turning radius")
+        if not ok:
+            failures.append(f"radius {radius:.3f} m, expected {expected:.3f}")
+
+    if omega is None:
+        print("    FAIL  no joint states received")
+        failures.append("no joint states received during: " + label)
+    else:
+        # The whole point of the file: physics against the plugin's own
+        # arithmetic. See the moduledoc — /odom cannot catch this alone.
+        ground = omega * WHEEL_RADIUS
+        print(f"    wheels {omega:.2f} rad/s -> ground speed {ground:.3f} m/s")
+        ok = within(ground, speed, GROUND_SPEED_TOLERANCE)
+        print(f"    {verdict(ok)} wheel radius agrees with odometry")
+        if not ok:
+            failures.append(
+                f"wheels turn at {omega:.2f} rad/s, i.e. {ground:.3f} m/s on "
+                f"{WHEEL_RADIUS} m wheels, but odometry claims {speed:.3f} m/s"
+            )
+
+    return failures
 
 
 def main():
@@ -116,13 +257,30 @@ def main():
     for _ in range(50):
         rclpy.spin_once(node, timeout_sec=0.02)
 
-    run(node, 1.0, 0.0, 7.0, "straight: 1.0 m/s, steady state  (expect 1.0 m/s)", settle=2.0)
-    run(node, 1.0, 0.5, 10.0, "turn: 1.0 m/s, 0.5 rad/s  (expect R = 2.0 m)", settle=3.0)
-    run(node, 2.0, 0.5, 10.0, "turn: 2.0 m/s, 0.5 rad/s  (expect R = 4.0 m)", settle=3.0)
+    failures = []
+    failures += run(
+        node, 1.0, 0.0, 7.0, "straight: 1.0 m/s, steady state  (expect 1.0 m/s)", settle=2.0
+    )
+    failures += run(
+        node, 1.0, 0.5, 10.0, "turn: 1.0 m/s, 0.5 rad/s  (expect R = 2.0 m)", settle=3.0
+    )
+    failures += run(
+        node, 2.0, 0.5, 10.0, "turn: 2.0 m/s, 0.5 rad/s  (expect R = 4.0 m)", settle=3.0
+    )
 
     node.destroy_node()
     rclpy.shutdown()
 
+    print()
+    if failures:
+        print(f"{len(failures)} failure(s):")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print("All drivetrain checks passed.")
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/ros2/simulation/scripts/nav2_test.py
+++ b/ros2/simulation/scripts/nav2_test.py
@@ -1,0 +1,268 @@
+"""Drive the simulated vehicle with Nav2 and check what it commanded.
+
+Reaching the goal is the weakest of the three things checked here, and
+on its own it would pass with a configuration that is wrong in ways
+that matter on a real car.
+
+## What this actually guards
+
+1. **The goal is reached.** Proves the whole chain: bt_navigator ->
+   planner -> MPPI -> `/cmd_vel_nav` (TwistStamped) -> the stamped
+   bridge -> `AckermannSteering`. Any broken link here shows up as a
+   goal that never completes.
+
+2. **The turning radius is honoured.** For every commanded pair,
+   `|wz| <= |vx| / min_turning_r`. This is the assertion that catches
+   `motion_model` being unset or renamed, which silently reverts MPPI
+   to `mppi::OmniMotionModel` — holonomic, and happy to command
+   sideways and spin-in-place velocities the vehicle cannot produce.
+   The car still reaches the goal in simulation when that happens,
+   because Gazebo's plugin quietly ignores what it cannot do. On the
+   real vehicle it would be commanding arcs tighter than the steering
+   can cut.
+
+3. **No in-place rotation is commanded.** `vx` at zero with `wz`
+   nonzero is the one command an Ackermann vehicle can never execute.
+   It is what `Spin` recovery produces, and what a goal checker
+   demanding a final heading produces. Both abort navigation on a car.
+
+Check 2 is the reason this file exists. It is the only one that fails
+when the kinematic model is wrong, and the whole point of running Nav2
+against this vehicle rather than a differential-drive one.
+
+## Two goals, because one cannot test both things
+
+An easy goal never exercises the radius limit: a goal 3 m ahead and 1 m
+across needs a 5 m arc, and a completely unconstrained controller
+drives it at 0.72x the limit — under the threshold, so the check
+passes. Measured, not assumed.
+
+A tight goal does exercise it, but the *correctly* configured vehicle
+then struggles to arrive: at a required 0.93 m arc against a 0.57 m
+minimum, the Ackermann run needed 1317 commands and still timed out
+0.46 m short. Asserting arrival there would be a gate that fails on
+good configuration.
+
+So each goal is asked only what it can answer:
+
+  * **reach** — 3 m ahead, 1 m across. Arrival is required. The
+    kinematic checks run too, but they are not what this leg is for.
+  * **turn** — 0.8 m ahead, 1.4 m across, a required arc of 0.93 m
+    against a 0.57 m minimum. Arrival is **not** required: the point is
+    what gets commanded while trying, and a car legitimately needs to
+    shuffle. The kinematic checks are the whole assertion.
+
+## Tolerances
+
+Arrival allows 0.60 m against `nav2.yaml`'s `xy_goal_tolerance` of
+0.30. MPPI stops the moment the checker is satisfied, so asserting
+tighter than the thing under test is a flaky restatement of it.
+
+The radius check gets 10% of slack. MPPI clamps the control sequence it
+samples, so a published command should satisfy the constraint exactly —
+the Ackermann run peaks at exactly 1.00x. The margin covers rounding,
+and is nowhere near the 404x an unconstrained model reaches.
+
+`STANDSTILL_WZ` is 0.15 rad/s to separate two different things that
+both show up as yaw near zero speed. Momentary transients as the
+vehicle starts and stops reach 0.081; a genuine attempt to rotate on
+the spot reached 0.359. A handful of transient samples is allowed for
+the same reason.
+"""
+
+import math
+import sys
+import time
+
+import rclpy
+from geometry_msgs.msg import TwistStamped
+from nav2_msgs.action import NavigateToPose
+from nav_msgs.msg import Odometry
+from rclpy.action import ActionClient
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+
+# From vehicles/ovcs_mini/description/ovcs_mini.urdf.xacro:
+#   wheelbase / tan(steering_limit) = 0.324 / tan(0.52) = 0.566 m
+# nav2.yaml rounds that up to 0.6 for margin. Stated here independently
+# so a change to one has to be a change to both, in a diff someone reads.
+MIN_TURNING_RADIUS = 0.6
+RADIUS_SLACK = 1.10
+
+GOAL_TOLERANCE = 0.60
+GOAL_TIMEOUT = 90.0
+
+# Below this speed a commanded yaw rate is an in-place rotation, which
+# this vehicle cannot perform at all. See the tolerance note above for
+# where these two numbers come from.
+STANDSTILL_VX = 0.05
+STANDSTILL_WZ = 0.15
+# Start/stop transients produce a few of these legitimately.
+STANDSTILL_ALLOWANCE = 8
+
+# (label, dx, dy, arrival required). See "Two goals" above.
+GOALS = [
+    ("reach: 3.0 m ahead, 1.0 m across", 3.0, 1.0, True),
+    ("turn: 0.8 m ahead, 1.4 m across (0.93 m arc vs 0.57 m minimum)", 0.8, 1.4, False),
+]
+
+
+class Navigator(Node):
+    def __init__(self):
+        super().__init__("nav2_test")
+        self.set_parameters([Parameter("use_sim_time", value=True)])
+        self.client = ActionClient(self, NavigateToPose, "navigate_to_pose")
+        self.create_subscription(Odometry, "/odom", self.on_odom, 10)
+        # TwistStamped, not Twist. Subscribing with the wrong type here
+        # would report zero commands and pass every check vacuously.
+        self.create_subscription(TwistStamped, "/cmd_vel_nav", self.on_cmd, 30)
+        self.pose = None
+        self.commands = []
+
+    def on_odom(self, message):
+        position = message.pose.pose.position
+        self.pose = (position.x, position.y)
+
+    def on_cmd(self, message):
+        self.commands.append((message.twist.linear.x, message.twist.angular.z))
+
+    def settle(self, seconds):
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            rclpy.spin_once(self, timeout_sec=0.05)
+
+
+def verdict(ok):
+    return "PASS " if ok else "FAIL "
+
+
+def check(failures, ok, label, detail):
+    print(f"  {verdict(ok)} {label}: {detail}")
+    if not ok:
+        failures.append(f"{label} — {detail}")
+
+
+def navigate(node, label, dx, dy, must_arrive, failures):
+    """Send one goal and check what was commanded on the way."""
+    node.commands = []
+    node.settle(1.0)
+    start = node.pose
+    target = (start[0] + dx, start[1] + dy)
+
+    goal = NavigateToPose.Goal()
+    goal.pose.header.frame_id = "odom"
+    goal.pose.header.stamp = node.get_clock().now().to_msg()
+    goal.pose.pose.position.x = target[0]
+    goal.pose.pose.position.y = target[1]
+    goal.pose.pose.orientation.w = 1.0
+
+    print()
+    print(label)
+
+    send = node.client.send_goal_async(goal)
+    rclpy.spin_until_future_complete(node, send, timeout_sec=20.0)
+    handle = send.result()
+
+    if handle is None or not handle.accepted:
+        check(failures, False, "goal accepted", "Nav2 rejected the goal")
+        return
+
+    result = handle.get_result_async()
+    deadline = time.time() + GOAL_TIMEOUT
+    while time.time() < deadline and not result.done():
+        rclpy.spin_once(node, timeout_sec=0.1)
+
+    status = result.result().status if result.done() else None
+    error = math.hypot(node.pose[0] - target[0], node.pose[1] - target[1])
+
+    if must_arrive:
+        check(
+            failures,
+            status == 4 and error <= GOAL_TOLERANCE,
+            "goal reached",
+            f"{error:.2f} m away, status {status if status else 'timed out'} "
+            f"(tolerance {GOAL_TOLERANCE:.2f})",
+        )
+    else:
+        # Reported, not asserted: a car legitimately needs to shuffle
+        # for an arc this tight, and demanding arrival here would fail
+        # on correct configuration. See the module docstring.
+        print(f"        (arrival not asserted: {error:.2f} m away, status {status})")
+
+    if not node.commands:
+        check(failures, False, "commands observed", "nothing published on /cmd_vel_nav")
+        return
+
+    # ── the turning radius ───────────────────────────────────────────
+    worst_ratio, worst = 0.0, (0.0, 0.0)
+    for vx, wz in node.commands:
+        allowed = abs(vx) / MIN_TURNING_RADIUS
+        ratio = abs(wz) / allowed if allowed > 1e-9 else (0.0 if abs(wz) < 1e-9 else math.inf)
+        if ratio > worst_ratio:
+            worst_ratio, worst = ratio, (vx, wz)
+
+    check(
+        failures,
+        worst_ratio <= RADIUS_SLACK,
+        "turning radius honoured",
+        f"worst |wz| was {worst_ratio:.2f}x the limit at "
+        f"vx={worst[0]:.3f}, wz={worst[1]:.3f} (R_min {MIN_TURNING_RADIUS} m)",
+    )
+
+    # ── in-place rotation ────────────────────────────────────────────
+    spins = [
+        (vx, wz)
+        for vx, wz in node.commands
+        if abs(vx) < STANDSTILL_VX and abs(wz) > STANDSTILL_WZ
+    ]
+    check(
+        failures,
+        len(spins) <= STANDSTILL_ALLOWANCE,
+        "no in-place rotation commanded",
+        f"{len(spins)} of {len(node.commands)} commands asked for yaw at a standstill "
+        f"(allowance {STANDSTILL_ALLOWANCE})"
+        + (f", worst wz={max(abs(w) for _, w in spins):.3f}" if spins else ""),
+    )
+
+    vxs = [c[0] for c in node.commands]
+    print(f"        vx range {min(vxs):+.3f} .. {max(vxs):+.3f} m/s")
+
+
+def main():
+    rclpy.init()
+    node = Navigator()
+    node.settle(3.0)
+
+    failures = []
+
+    if node.pose is None:
+        print("  FAIL  no odometry — is the simulator running?")
+        rclpy.shutdown()
+        return 1
+
+    if not node.client.wait_for_server(timeout_sec=30.0):
+        print("  FAIL  navigate_to_pose action server never appeared")
+        print("        Nav2 did not finish its lifecycle bringup.")
+        rclpy.shutdown()
+        return 1
+
+    print(f"Start pose: ({node.pose[0]:.2f}, {node.pose[1]:.2f})")
+
+    for label, dx, dy, must_arrive in GOALS:
+        navigate(node, label, dx, dy, must_arrive, failures)
+
+    rclpy.shutdown()
+
+    print()
+    if failures:
+        print(f"{len(failures)} failure(s):")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+
+    print("All Nav2 checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ros2/simulation/verify_drivetrain.sh
+++ b/ros2/simulation/verify_drivetrain.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Bring up the simulator, drive it, check the odometry against the
+# geometry the model claims, tear it all down. One command, exit code
+# says whether the drivetrain is still correct.
+#
+# The sibling of verify_perception.sh, and much smaller, because this
+# loop never leaves ROS: sim → /odom → drive_test.py. No CAN, no BEAM,
+# no detector — so none of the preflight that verify_perception.sh
+# needs applies here.
+#
+# It exists for one bug class: the model's wheel radius was once wrong
+# by 2x, which reports 2x the distance travelled while looking
+# perfectly fine on screen. Nothing catches that but driving and
+# measuring.
+#
+# Usage:
+#   ./verify_drivetrain.sh              # up, check, down
+#   KEEP_UP=1 ./verify_drivetrain.sh    # leave it running to poke at
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+BASE="$REPO/ros2/base"
+
+KEEP_UP="${KEEP_UP:-0}"
+
+log()  { printf '\n\033[1;36m▸\033[0m %s\n' "$1"; }
+fail() { printf '\033[31m✗\033[0m %s\n' "$1" >&2; }
+
+cleanup() {
+  local code=$?
+  if [ "$KEEP_UP" = "1" ]; then
+    log "KEEP_UP=1 — leaving the stack running"
+    printf '  stop with: (cd %s && docker compose down) && (cd %s && docker compose rm -sf ros2 zenohd)\n' \
+      "$HERE" "$BASE"
+    return $code
+  fi
+  log "Tearing down"
+  (cd "$HERE" && timeout 120 docker compose down >/dev/null 2>&1)
+  (cd "$BASE" && timeout 120 docker compose rm -sf ros2 zenohd >/dev/null 2>&1)
+  return $code
+}
+trap cleanup EXIT
+
+# ── up ──────────────────────────────────────────────────────────────
+log "Starting the Zenoh router"
+(cd "$BASE" && ZENOH_ENDPOINT_IP=127.0.0.1 timeout 180 docker compose \
+  --profile standalone up -d zenohd ros2) || { fail "router/ros2 failed to start"; exit 1; }
+
+# empty.sdf would do — nothing here needs texture to correlate against,
+# unlike the perception check — but sharing workshop.sdf keeps the two
+# verifiers on one world, so a model change is exercised the same way
+# by both.
+log "Starting the simulator"
+(cd "$HERE" && timeout 300 docker compose up -d) || { fail "sim failed to start"; exit 1; }
+
+# ros2_control needs to have claimed the joints and started publishing
+# /odom before the first command means anything.
+sleep 20
+
+# ── check ───────────────────────────────────────────────────────────
+log "Driving the vehicle and measuring what odometry reports"
+# Piped over stdin rather than run from the mount, matching
+# verify_perception.sh: scripts/ is mounted into the *sim* container,
+# but the checks want the base station's rclpy so they talk to the
+# same Zenoh router everything else does.
+(cd "$BASE" && timeout 300 docker compose exec -T ros2 bash -lc \
+  'source /opt/ros/*/setup.bash 2>/dev/null; exec python3 -') \
+  < "$HERE/scripts/drive_test.py"
+result=$?
+
+[ "$result" -ne 0 ] && fail "drivetrain checks failed"
+
+exit "$result"

--- a/ros2/simulation/verify_nav2.sh
+++ b/ros2/simulation/verify_nav2.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Bring up the simulator and Nav2, send a goal, check what Nav2
+# commanded, tear it all down. One command, exit code says whether Nav2
+# can still drive an Ackermann vehicle.
+#
+# The third sibling of verify_perception.sh and verify_drivetrain.sh.
+# Slower than both, because it waits for Nav2's lifecycle bringup and
+# then for the vehicle to actually drive somewhere.
+#
+# What it is really for is the turning-radius check. Nav2 reaching a
+# goal in simulation proves less than it appears to: Gazebo's
+# AckermannSteering quietly ignores commands it cannot execute, so a
+# configuration that has reverted to the holonomic default still
+# arrives. See scripts/nav2_test.py.
+#
+# Usage:
+#   ./verify_nav2.sh              # up, navigate, check, down
+#   KEEP_UP=1 ./verify_nav2.sh    # leave it running to poke at
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+BASE="$REPO/ros2/base"
+
+KEEP_UP="${KEEP_UP:-0}"
+
+log()  { printf '\n\033[1;36m▸\033[0m %s\n' "$1"; }
+fail() { printf '\033[31m✗\033[0m %s\n' "$1" >&2; }
+
+cleanup() {
+  local code=$?
+  if [ "$KEEP_UP" = "1" ]; then
+    log "KEEP_UP=1 — leaving the stack running"
+    printf '  nav2 log: docker logs ovcs-nav2\n'
+    printf '  stop with: (cd %s && docker compose --profile nav2 down) && (cd %s && docker compose rm -sf ros2 zenohd)\n' \
+      "$HERE" "$BASE"
+    return $code
+  fi
+  log "Tearing down"
+  (cd "$HERE" && timeout 120 docker compose --profile nav2 down >/dev/null 2>&1)
+  (cd "$BASE" && timeout 120 docker compose rm -sf ros2 zenohd >/dev/null 2>&1)
+  return $code
+}
+trap cleanup EXIT
+
+# ── up ──────────────────────────────────────────────────────────────
+log "Starting the Zenoh router"
+(cd "$BASE" && ZENOH_ENDPOINT_IP=127.0.0.1 timeout 180 docker compose \
+  --profile standalone up -d zenohd ros2) || { fail "router/ros2 failed to start"; exit 1; }
+
+log "Starting the simulator"
+(cd "$HERE" && ZENOH_ENDPOINT_IP=127.0.0.1 timeout 300 docker compose up -d) \
+  || { fail "sim failed to start"; exit 1; }
+
+# ros2_control has to have claimed the joints and be publishing /odom
+# and /tf before Nav2's costmaps will accept a transform.
+sleep 20
+
+log "Starting Nav2"
+(cd "$HERE" && ZENOH_ENDPOINT_IP=127.0.0.1 timeout 300 docker compose --profile nav2 up -d nav2) \
+  || { fail "nav2 failed to start"; exit 1; }
+
+# Lifecycle bringup is sequential across five nodes and each waits on
+# a transform. A failure here is otherwise reported as "the action
+# server never appeared", which reads like a discovery problem.
+sleep 30
+if ! docker logs ovcs-nav2 2>&1 | grep -q "Managed nodes are active"; then
+  fail "Nav2 did not finish lifecycle bringup:"
+  docker logs ovcs-nav2 2>&1 | grep -iE "FATAL|ERROR" | tail -15 >&2
+  exit 1
+fi
+
+# ── check ───────────────────────────────────────────────────────────
+log "Navigating to a goal and checking what Nav2 commanded"
+# Run inside the nav2 container, not the base station's: the checks
+# need nav2_msgs for the NavigateToPose action, which only this image
+# has. Piped over stdin for the same reason as the other two verifiers
+# — scripts/ is mounted into the *sim* container.
+(timeout 300 docker exec -i ovcs-nav2 bash -lc \
+  'source /opt/ros/lyrical/setup.bash 2>/dev/null; exec python3 -') \
+  < "$HERE/scripts/nav2_test.py"
+result=$?
+
+if [ "$result" -ne 0 ]; then
+  fail "Nav2 checks failed — last of the nav2 log:"
+  docker logs ovcs-nav2 2>&1 | tail -20 >&2
+fi
+
+exit "$result"

--- a/vehicles/ovcs_mini/description/gazebo_ackermann.xacro
+++ b/vehicles/ovcs_mini/description/gazebo_ackermann.xacro
@@ -10,11 +10,21 @@
   through `ros_gz_bridge` rather than by linking ROS into the plugin.
 
   Every geometry value below is read from the properties in
-  `ovcs_mini.urdf.xacro`, never retyped. The plugin computes odometry
-  from `wheel_radius` and `wheel_separation`, so a number that
-  disagrees with the model produces a vehicle that drives correctly
-  and *reports* the wrong distance — which is exactly the failure the
-  previous model shipped with, its 0.1 m wheels against a real 0.0548.
+  `ovcs_mini.urdf.xacro`, never retyped. That matters because of the
+  failure the previous model shipped with: 0.1 m wheels declared
+  against a real 0.0548.
+
+  The shape of that failure under gz-sim 10 is the opposite of what
+  one would expect, and was measured rather than assumed (see
+  `ros2/simulation/scripts/drive_test.py`). The radius cancels in the
+  plugin — commanded speed is divided by it to get a joint velocity,
+  and the joint velocity is multiplied by it again to get odometry —
+  so `/odom` reads a flawless 1.000 m/s while the car actually crawls
+  at 0.548. The vehicle *reports* correctly and **drives** wrong.
+
+  Which means `/odom` cannot catch it. `drive_test.py` compares the
+  physical joint velocity from `/joint_states` against what odometry
+  claims, and that comparison is what fails.
 
   Tag names here were read out of the shipped
   `libgz-sim-ackermann-steering-system.so` and the reference world


### PR DESCRIPTION
## Two merged PRs never reached main

`#48` (Nav2 gate) and `#49` (drivetrain gate) both show as merged, and neither is on `main`. They were merged into their **base branches** — `feat-nav2-sim` and `feat-local-detector-backends` — which had *already* been merged to main. So the merge landed on a branch nobody would merge again, and the content went nowhere.

Verified before this PR:

```
MISSING  ros2/simulation/verify_nav2.sh
MISSING  ros2/simulation/scripts/nav2_test.py
MISSING  ros2/simulation/verify_drivetrain.sh
mise.toml: only [tasks.verify-perception]
drive_test.py: no assertions, no /joint_states check
```

This restores both commits by cherry-pick, unchanged apart from conflict resolution.

A stacked PR has to merge **before** its parent, or be retargeted to `main` after; with `--delete-branch` on the parent it is worse, since that is what closed #51 and left its branch to be restored.

## What comes back

**The Nav2 gate** — `verify_nav2.sh`, `nav2_test.py`, `mise run verify-nav2`. Asserts on what Nav2 *commanded*, not where it arrived, because substituting `mppi::DiffDriveMotionModel` reached the tight goal **better** than the correct config (0.30 m vs 0.53 m) while commanding 3.68× the kinematic limit. Two goals, because measurement showed no single goal tests both arrival and the limits.

**The drivetrain gate** — `verify_drivetrain.sh`, `mise run verify-drivetrain`, and `drive_test.py` asserting instead of printing. Including the finding that **`/odom` cannot catch a wrong wheel radius**: with `<wheel_radius>` at 0.1 against the real 0.0548 every check passed while the car crawled at 0.548 m/s, because the radius cancels inside the plugin. It now checks `/joint_states` against odometry. The stale claim in `gazebo_ackermann.xacro` is corrected.

## Conflicts, and how they were resolved

Two, both in `mise.toml`, both because each commit inserted a task before `[tasks.cli]` and `main` has since gained `fetch-models`. All four tasks are kept:

```
[tasks.verify-perception]
[tasks.verify-drivetrain]
[tasks.verify-nav2]
[tasks.fetch-models]
```

`gazebo_ackermann.xacro` merged cleanly — the drivetrain commit's comment correction and the Nav2 PR's `<frame_id>odom</frame_id>` coexist.

## Verification

Both gates run green on top of merged `main`, not just on their original branches:

```
verify-drivetrain  EXIT=0   wheels 18.25 rad/s -> 1.000 m/s, radius 2.083 / 3.830
verify-nav2        EXIT=0   radius 0.59x then exactly 1.00x, zero standstill commands
```

`ruff check .` clean; both shell scripts parse.

## Suggestion

Merged remote branches are worth deleting as they go — `ci-lint-python`, `fix-joy-drive-path` and `fix-ros-control-staleness` are fully merged and still present. But **not** `feat-nav2-sim` or `feat-local-detector-backends` until this lands: right now they are the only place these two commits exist.
