### PR TITLE
docs: make the simulator findable, and fix the toolchain versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,12 +205,13 @@ Subscribe to the [Spin42 Engineering YouTube channel](https://www.youtube.com/@s
 Full documentation is in the [`docs/`](./docs/README.md) directory:
 
 1. [Getting Started](./docs/getting_started.md) — environment setup and installation
-2. [Applications](./docs/applications.md) — what each app and library is, plus local-dev
-3. [Vehicle Parameterisation](./docs/vehicle_parameterisation.md) — how `VEHICLE` selects a composer and what each firmware boots
-4. [Hardware Architecture](./docs/hardware_architecture.md) — physical topology, CAN networks, controllers
-5. [Running on Hardware](./docs/running_hardware.md) — firmware build/burn/upload + runtime debugging via the `ovcs` CLI
-6. [Testing CAN Messages](./docs/testing_can_messages.md) — simulating CAN traffic
-7. [Testing Generic Controllers](./docs/testing_generic_controllers.md) — adopting + verifying generic Arduino controllers
+2. [Simulation](./ros2/simulation/README.md) — drive a simulated OVCS Mini in Gazebo, no hardware needed
+3. [Applications](./docs/applications.md) — what each app and library is, plus local-dev
+4. [Vehicle Parameterisation](./docs/vehicle_parameterisation.md) — how `VEHICLE` selects a composer and what each firmware boots
+5. [Hardware Architecture](./docs/hardware_architecture.md) — physical topology, CAN networks, controllers
+6. [Running on Hardware](./docs/running_hardware.md) — firmware build/burn/upload + runtime debugging via the `ovcs` CLI
+7. [Testing CAN Messages](./docs/testing_can_messages.md) — simulating CAN traffic
+8. [Testing Generic Controllers](./docs/testing_generic_controllers.md) — adopting + verifying generic Arduino controllers
 
 ## Disclaimer
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Index for the Open Vehicle Control System guides. For a high-level project overv
 - [Hardware Architecture](./hardware_architecture.md) — design principles, component layout, CAN bus topology and bitrates.
 - [Toolchain and OTP Versions](./toolchain_and_otp.md) — why the host Elixir/OTP pin in `mise.toml` is coupled to each Nerves target's OTP version, what the A/B partition layout requires of firmware, and how to follow a system fork upstream again.
 - [ROS Compute Node](./ros_compute_node.md) — the OVCS Mini's non-Nerves Pi: why it exists, the immutable OS choice (balenaOS), the vehicule/base compose split, and how it wires into the Zenoh fabric.
+- [Simulation](../ros2/simulation/README.md) — the Gazebo Jetty model of the OVCS Mini: how to run it, drive it with a gamepad, point the real perception pipeline at it, navigate it with Nav2, and the three verifiers that check depth, drivetrain and navigation against the world. **The quickest way to see this project do something without hardware.**
 - [ROS Perception Detection](./ros_perception_detection.md) — object detection on the Hailo-8: why detection and not disparity, what it costs the stereo rate, how a 2D box becomes a 3D position, and the two topics it publishes.
 - [Running on Hardware](./running_hardware.md) — Nerves targets, the `ovcs` CLI for build / burn / OTA upload, attach / connect for runtime debugging.
 - [OVCS1 Wiring Reference](../vehicles/ovcs1/WIRING.md) — pin-level wiring for the OVCS1 vehicle (Leaf harness, iBooster, steering pump, Polo CAN bus).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -11,13 +11,14 @@ OVCS is developed on Linux. macOS users need a Linux VM (see [macOS setup](#loca
 | Tool | Version | Purpose | Managed by |
 |------|---------|---------|------------|
 | [mise](https://mise.jdx.dev/) | Latest | Version manager for language runtimes | you (one-time install) |
-| Erlang/OTP | 27.3+ | Runtime for Elixir | mise |
-| Elixir | 1.17+ | Primary programming language | mise |
+| Erlang/OTP | **28.x** (28.4.1 pinned) | Runtime for Elixir | mise |
+| Elixir | **1.19.x** (1.19.5-otp-28 pinned) | Primary programming language | mise |
 | Rust | 1.90+ | Compiles the top-level `ovcs` CLI (native binary at `cli/ovcs`) | mise |
 | Node.js | 24+ | VMS debug dashboard (Vue.js) | mise |
 | Ruby | 3.3+ | Utility scripts under `scripts/` (e.g. `bind_remote_can.rb`, `faker.rb`) | mise |
 | Python | 3.12+ | PlatformIO + misc tooling | mise |
 | [Flutter](https://flutter.dev/docs/get-started/install) | 3.32.8 | Infotainment dashboard | mise |
+| Docker + Compose v2 | Latest | The Gazebo simulator, the ROS base station, and the ROS compute node all run in containers (see [Simulation](../ros2/simulation/README.md)) | system package |
 | can-utils | Latest | CAN bus utilities (`cansend`, `candump`, `canplayer`) | system package |
 | `fwup` | Latest | Nerves firmware image packager | system package |
 | `libsocketcan-dev` | Latest | Cantastic native CAN bindings | system package (firmware builds only) |
@@ -25,6 +26,13 @@ OVCS is developed on Linux. macOS users need a Linux VM (see [macOS setup](#loca
 | `nerves_bootstrap` | Latest | Nerves Mix archive | `mise run bootstrap` |
 | [PlatformIO](https://platformio.org/) | Latest | Arduino controller firmware | mise (via pipx + uv) |
 | [balena CLI](https://docs.balena.io/reference/balena-cli/) | 25.x | Deploys the ROS compute node's containers (see [ROS Compute Node](./ros_compute_node.md)) | mise |
+
+The Erlang and Elixir entries are **exact**, not minimums. Every Nerves
+target in this repo ships the OTP 28 line, and Mix refuses to
+cross-compile across major OTP versions — so a host on OTP 27 builds
+nothing for hardware, and an Elixir older than 1.19 will not compile
+the tree. `mise install` gives you the right ones; see
+[Toolchain and OTP Versions](./toolchain_and_otp.md) for the coupling.
 
 ## Linux Setup
 

--- a/ros2/simulation/README.md
+++ b/ros2/simulation/README.md
@@ -33,14 +33,23 @@ Adding a vehicle is a `description/` directory under it containing
 docker compose exec sim ros2 launch /opt/ovcs/launch/sim.launch.py vehicle:=<name>
 ```
 
-## Running it
+## Quickstart
+
+The simulator itself needs **Docker and Compose v2** and nothing else —
+no Nerves toolchain, no CAN interface, no vehicle. First run pulls and
+builds images, so budget a few minutes.
+
+One of the extras below wants more than that, and it is called out
+where it appears.
 
 ```sh
-# A router, if you have no vehicle on the LAN.
+cd ros2/simulation
+
+# A Zenoh router, if there is no vehicle on the LAN to peer with.
 docker compose -f ../base/docker-compose.yml --profile standalone up -d zenohd
 
-docker compose up -d
-docker compose logs -f sim
+docker compose up -d          # the simulator
+docker compose logs -f sim    # ^C once it settles
 ```
 
 Drive it:
@@ -51,18 +60,62 @@ docker compose exec sim bash -lc \
      "{linear: {x: 1.0}, angular: {z: 0.3}}"'
 ```
 
-Two things are **separate services**, so the simulation itself needs
-neither a display nor a gamepad — `docker compose up` works on a bare
-machine:
+Watch it move, in another shell:
 
 ```sh
-# gamepad
-docker compose --profile teleop up -d teleop
+docker compose exec sim bash -lc 'ros2 topic echo /odom --once'
+```
 
-# Gazebo GUI
+See it:
+
+```sh
 xhost +local:docker
 docker compose --profile gui up -d gz-gui
 ```
+
+Then, in rough order of how much each adds:
+
+| | command | what it gives you | needs |
+|---|---|---|---|
+| gamepad | `docker compose --profile teleop up -d teleop` | drive it with a stick instead of `topic pub` | a joystick at `/dev/input/js0` |
+| drivetrain | `mise run verify-drivetrain` | odometry checked against the model's geometry | Docker only |
+| navigation | `mise run verify-nav2` | Nav2 planning and driving to a goal | Docker only |
+| depth | `mise run verify-perception` | the **real** stereo pipeline, checked against the world | see below |
+
+The three `verify-*` tasks bring the whole stack up, assert, and tear
+it down, so each is a single command that either passes or tells you
+what broke. They are also the fastest way to see what this simulator is
+*for*: each one exists because it caught something that looked fine on
+screen.
+
+`verify-perception` is the one that needs more, because it runs the
+actual Elixir perception bridge rather than a ROS node — so it wants
+the `mise` toolchain (`mise install`) and a `vcan0` interface, because
+Cantastic will not start without a CAN network:
+
+```sh
+mise run cli                  # builds ./ovcs, needs Rust
+./ovcs can setup ovcs_mini    # creates vcan0, needs sudo
+```
+
+It checks for `vcan0` up front and tells you this if it is missing, so
+running it first costs nothing but a clear error.
+
+**Stop driving it before you run a `verify-*` task.** Nothing arbitrates
+`/cmd_vel`: a `topic pub` left running, or the teleop service still up,
+publishes against the verifier's own commands and it fails in a way
+that does not name the cause. `^C` the publisher, or
+`docker compose stop teleop`, first. (Nav2 uses a separate topic and
+does not collide.)
+
+Tear down with `docker compose down` here, plus
+`docker compose rm -sf zenohd` in `../base`.
+
+## The GUI and the gamepad are separate services
+
+Deliberately, so the simulation itself needs neither a display nor a
+gamepad — `docker compose up -d` works on a headless machine, which is
+what the CI-shaped `verify-*` tasks rely on.
 
 ## Verifying it
 


### PR DESCRIPTION
Audited every markdown file in the tree against the code.

## The good news

- **0 broken relative links** across 52 files. The seven a checker flags are in the vehicle *template*, where `../../docs/…` resolves correctly once instantiated at `vehicles/<name>/`.
- **0 dead file references.** The ten flagged are device files (balenaOS `config.json`), model-zoo URLs, runtime-generated paths (`/tmp/zenoh-session.json5`), or naming conventions for drivers that don't exist yet.
- **Every documented `mise run` task exists** (all 8), and **every documented `./ovcs` subcommand exists** — checked against the built binary's own `--help`, since the command names differ from the source file names.
- **No stale distro claims.** The Jazzy/Harmonic mentions that remain are explicitly historical, in the section explaining the move to Lyrical/Jetty.
- **The documented sim startup commands work verbatim** — run from cold.

## Three real problems, all in the path a newcomer walks

### 1. The toolchain versions were wrong

`getting_started.md` asked for **"Erlang/OTP 27.3+"** and **"Elixir 1.17+"**. Both are impossible:

- `mise.toml` pins `28.4.1` and `1.19.5-otp-28`
- every Nerves target in the tree ships the OTP 28 line
- Mix refuses to cross-compile across major OTP versions

Someone installing OTP 27.3 builds nothing for hardware and gets no hint why. The rows are now exact rather than minimums, with a note saying why they aren't a floor.

### 2. Docker wasn't a listed prerequisite at all

Despite the Gazebo simulator, the ROS base station and the ROS compute node all running in containers.

### 3. The simulator was invisible

`ros2/simulation/README.md` is **421 lines** — the most useful document here for anyone wanting to see this project *do something* — and it had **zero inbound links**. Absent from the twelve-entry docs index, absent from the top-level README. The only route to `ros2/README.md` at all was one link buried in `ros_compute_node.md:35`.

Both entry points now point at it, and it gains a **Quickstart**, because the existing "Running it" section was correct but assumed you already knew what this was for.

## Two things the quickstart run surfaced

**The prerequisites aren't uniform.** `verify-drivetrain` and `verify-nav2` need Docker and nothing else. `verify-perception` runs the actual Elixir bridge, so it needs the mise toolchain and a `vcan0`. Writing "Docker and nothing else" across all of them would have been the same class of error as the OTP row, so the table says which is which.

**Nothing arbitrates `/cmd_vel`.** A `topic pub` left running fails a verifier without naming the cause — which is easy to hit while following the quickstart. Now called out where the verifiers are introduced.

## Verification

Every command in the new Quickstart was run verbatim from a cold start:

```
router up ✓   sim up ✓   topic pub moves the car (x=3.79, y=4.77) ✓
mise run verify-drivetrain → all checks passed ✓
```

All new links resolve.

## Is there enough to start playing with the simulation?

Yes. Gazebo Jetty with the OVCS Mini model, gamepad teleop, the real stereo perception pipeline, Nav2 navigating to goals, a Foxglove layout, and three verifiers that assert against the world. The gap was never substance; it was that nothing told you it existed.
