### PR TITLE
feat(ovcs_vehicle): geometry/0, so vms_core can do kinematics generically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,14 @@ jobs:
           - bridges/firmware
           - bridges/radio_control_bridge
           - bridges/ros_bridge
+          # Vehicles were missing here while the libmnl step below
+          # already special-cased them, so a test in a vehicle
+          # package never ran. `vehicles/ovcs_mini` has one now —
+          # the geometry check that keeps `geometry/0` and the
+          # simulation model in agreement.
+          - vehicles/ovcs1
+          - vehicles/ovcs_mini
+          - vehicles/obd2
     defaults:
       run:
         working-directory: ${{ matrix.project }}

--- a/libraries/ovcs_vehicle/lib/ovcs_vehicle.ex
+++ b/libraries/ovcs_vehicle/lib/ovcs_vehicle.ex
@@ -28,6 +28,30 @@ defmodule OvcsVehicle do
           }
         }
 
+  @typedoc """
+  A vehicle's measured physical geometry, in SI units — metres and
+  radians, never millimetres or degrees.
+
+  This exists so `vms_core` can stay free of vehicle-specific code
+  while still doing work that needs to know the vehicle's shape.
+  Kinematics is the case that forces it: converting a velocity command
+  into a steering angle is `atan(wheelbase * omega / v)`, which is the
+  same arithmetic for every Ackermann vehicle and a different number
+  for each one. Generic code, vehicle-specific data, supplied at
+  instantiation.
+
+  Only *measured* quantities belong here. Anything derivable is a
+  function — see `min_turning_radius/1` — because a stored derived
+  value is one more copy to get wrong, and the copies are the problem
+  this type exists to bound.
+  """
+  @type geometry :: %{
+          required(:wheelbase) => float(),
+          required(:track) => float(),
+          required(:wheel_radius) => float(),
+          required(:steering_limit) => float()
+        }
+
   @callback name() :: String.t()
   @callback vms() :: module()
   @callback infotainment() :: module()
@@ -36,5 +60,58 @@ defmodule OvcsVehicle do
   @callback vms_target() :: atom()
   @callback infotainment_target() :: atom()
 
-  @optional_callbacks [infotainment: 0, infotainment_target: 0, bridge_firmwares: 0]
+  @doc """
+  The vehicle's measured physical geometry.
+
+  Optional: a package that only ever reads a bus — `Obd2` is one — has
+  no geometry to declare, and a vehicle whose numbers have not been
+  measured should omit this rather than guess. Components that need it
+  take it as an option from the composer, so a missing implementation
+  is a compile-time absence rather than a runtime surprise.
+  """
+  @callback geometry() :: geometry()
+
+  @optional_callbacks [
+    infotainment: 0,
+    infotainment_target: 0,
+    bridge_firmwares: 0,
+    geometry: 0
+  ]
+
+  @doc """
+  Tightest circle the vehicle can drive, in metres: `wheelbase /
+  tan(steering_limit)`.
+
+  Derived rather than declared, deliberately. It is the bound every
+  velocity command has to respect — a yaw rate above `v / this` asks
+  for an arc the steering cannot cut — so it wants a single definition
+  rather than a number copied into each caller.
+
+      iex> OvcsVehicle.min_turning_radius(%{wheelbase: 0.324, steering_limit: 0.52})
+      0.5658777495831087
+  """
+  @spec min_turning_radius(geometry()) :: float()
+  def min_turning_radius(%{wheelbase: wheelbase, steering_limit: steering_limit})
+      when steering_limit > 0 do
+    wheelbase / :math.tan(steering_limit)
+  end
+
+  @doc """
+  Largest yaw rate achievable at `speed`, in rad/s.
+
+  Zero at a standstill, and that is not an edge case to work around —
+  an Ackermann vehicle genuinely cannot rotate on the spot. Callers
+  that receive `(v = 0, omega != 0)` have to decide what to do about
+  it; this only tells them the command is unachievable.
+
+      iex> geometry = %{wheelbase: 0.324, steering_limit: 0.52}
+      iex> OvcsVehicle.max_yaw_rate(geometry, 1.0)
+      1.767166142752063
+      iex> OvcsVehicle.max_yaw_rate(geometry, 0.0)
+      0.0
+  """
+  @spec max_yaw_rate(geometry(), number()) :: float()
+  def max_yaw_rate(geometry, speed) do
+    abs(speed) / min_turning_radius(geometry)
+  end
 end

--- a/libraries/ovcs_vehicle/priv/templates/vehicle/lib/{{name}}.ex
+++ b/libraries/ovcs_vehicle/priv/templates/vehicle/lib/{{name}}.ex
@@ -16,7 +16,33 @@ defmodule <%= @module %> do
   def vms_target, do: :<%= @vms_target %>
 <%= if @infotainment do %>  @impl OvcsVehicle
   def infotainment_target, do: :<%= @infotainment_target %>
-<% end %><%= if @bridges do %>
+<% end %>
+  # Measured physical geometry — optional, in **metres and radians**.
+  #
+  # Declare it if anything on this vehicle needs to know its shape.
+  # Kinematics is the case that forces it: turning a velocity command
+  # into a steering angle is the same arithmetic on every Ackermann
+  # vehicle and a different number on each one, so `vms_core` stays
+  # generic and takes these as composer options.
+  #
+  # Only measured quantities go here. Derived ones are functions —
+  # `OvcsVehicle.min_turning_radius/1`, `max_yaw_rate/2` — because a
+  # stored derived value is one more copy to get wrong.
+  #
+  # If this vehicle also has a simulation model, the same numbers live
+  # in its xacro and cannot be shared, so add a test asserting the two
+  # agree. See `vehicles/ovcs_mini/test/geometry_test.exs`; a wheel
+  # radius wrong by 2x shipped in that model once.
+  #
+  # @impl OvcsVehicle
+  # def geometry,
+  #   do: %{
+  #     wheelbase: 0.0,
+  #     track: 0.0,
+  #     wheel_radius: 0.0,
+  #     steering_limit: 0.0
+  #   }
+<%= if @bridges do %>
   # Bridge firmwares — optional. Uncomment and populate to declare one
   # or more bridge firmware images for this vehicle. Each entry becomes
   # its own build target: `./ovcs build <%= @name %> bridge-<firmware-id>`.

--- a/libraries/ovcs_vehicle/test/ovcs_vehicle_test.exs
+++ b/libraries/ovcs_vehicle/test/ovcs_vehicle_test.exs
@@ -1,7 +1,28 @@
 defmodule OvcsVehicleTest do
   use ExUnit.Case, async: true
 
-  test "scaffolded placeholder" do
-    assert true
+  # The worked examples in `min_turning_radius/1` and `max_yaw_rate/2`
+  # are the numbers OVCS Mini actually runs with, so running them keeps
+  # the docs from drifting into fiction.
+  doctest OvcsVehicle
+
+  test "min_turning_radius refuses a vehicle that cannot steer" do
+    # Zero steering limit means no achievable arc at all. Better to
+    # fail the guard than divide by tan(0) and hand back infinity that
+    # something downstream treats as a very wide turn.
+    assert_raise FunctionClauseError, fn ->
+      OvcsVehicle.min_turning_radius(%{wheelbase: 0.324, steering_limit: 0.0})
+    end
+  end
+
+  test "max_yaw_rate is symmetric in the sign of speed" do
+    geometry = %{wheelbase: 0.324, steering_limit: 0.52}
+    assert OvcsVehicle.max_yaw_rate(geometry, -2.0) == OvcsVehicle.max_yaw_rate(geometry, 2.0)
+  end
+
+  test "a longer wheelbase cannot turn as tightly" do
+    tight = OvcsVehicle.min_turning_radius(%{wheelbase: 0.324, steering_limit: 0.52})
+    polo = OvcsVehicle.min_turning_radius(%{wheelbase: 2.466, steering_limit: 0.52})
+    assert polo > tight
   end
 end

--- a/vehicles/ovcs_mini/lib/ovcs_mini.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini.ex
@@ -12,6 +12,25 @@ defmodule OvcsMini do
   def name, do: "OVCS Mini"
   @impl OvcsVehicle
   def vms, do: OvcsMini.Vms.Composer
+  # Measured, in metres and radians. These are declared twice on
+  # purpose: here, and as `<xacro:property>` values in
+  # `description/ovcs_mini.urdf.xacro`, because xacro cannot read
+  # Elixir and the simulator needs them at model-generation time.
+  #
+  # `test/geometry_test.exs` asserts the two declarations agree, which
+  # is what makes the duplication safe rather than silent. That check
+  # is not decoration: a wheel radius wrong by 2x already shipped in
+  # this model once, drove convincingly, and reported nonsense — see
+  # `ros2/simulation/scripts/drive_test.py`.
+  @impl OvcsVehicle
+  def geometry,
+    do: %{
+      wheelbase: 0.324,
+      track: 0.296,
+      wheel_radius: 0.0548,
+      steering_limit: 0.52
+    }
+
   @impl OvcsVehicle
   def can_config_otp_app, do: :ovcs_mini
   @impl OvcsVehicle

--- a/vehicles/ovcs_mini/test/geometry_test.exs
+++ b/vehicles/ovcs_mini/test/geometry_test.exs
@@ -1,0 +1,90 @@
+defmodule OvcsMini.GeometryTest do
+  @moduledoc """
+  Keeps `OvcsMini.geometry/0` and the simulation model telling the same
+  story.
+
+  The vehicle's dimensions are declared twice and have to be: xacro
+  cannot read Elixir, and the simulator needs them at
+  model-generation time. Duplication is the price; this test is what
+  stops it being silent.
+
+  It is not a hypothetical. This model shipped with a wheel radius
+  wrong by a factor of two — it drove convincingly and reported
+  nonsense, and `/odom` could not catch it because the plugin's
+  arithmetic cancels the radius out. A comparison of the two
+  declarations catches that class of error in milliseconds, where the
+  simulator needs a full drive to.
+  """
+  use ExUnit.Case, async: true
+
+  @xacro Path.expand("../description/ovcs_mini.urdf.xacro", __DIR__)
+
+  # `<xacro:property name="wheelbase" value="0.324" />`, tolerating
+  # arbitrary whitespace and attribute order as written today.
+  defp xacro_property(name) do
+    source = File.read!(@xacro)
+
+    case Regex.run(
+           ~r/<xacro:property\s+name="#{name}"\s+value="([^"]+)"/,
+           source
+         ) do
+      [_, value] ->
+        {parsed, ""} = Float.parse(value)
+        parsed
+
+      nil ->
+        flunk("""
+        No <xacro:property name="#{name}"> in #{@xacro}.
+
+        Either it was renamed, or the property is now computed. Either
+        way this test cannot check it any more and needs updating —
+        do not delete the assertion, because that is the check that
+        keeps the two declarations honest.
+        """)
+    end
+  end
+
+  describe "geometry/0 agrees with the simulation model" do
+    for key <- [:wheelbase, :track, :wheel_radius, :steering_limit] do
+      test "#{key}" do
+        key = unquote(key)
+        declared = Map.fetch!(OvcsMini.geometry(), key)
+        modelled = xacro_property(to_string(key))
+
+        assert_in_delta declared,
+                        modelled,
+                        1.0e-9,
+                        "OvcsMini.geometry()[#{inspect(key)}] is #{declared}, " <>
+                          "but the xacro says #{modelled}. One of them is wrong; " <>
+                          "measure the vehicle rather than picking a side."
+      end
+    end
+
+    test "every measured quantity is checked" do
+      # Guards against adding a field to geometry/0 and forgetting to
+      # cover it here, which would reintroduce exactly the silent
+      # duplication this file exists to prevent.
+      assert MapSet.new(Map.keys(OvcsMini.geometry())) ==
+               MapSet.new([:wheelbase, :track, :wheel_radius, :steering_limit])
+    end
+  end
+
+  describe "derived values" do
+    test "the minimum turning radius follows from the declared geometry" do
+      # 0.324 / tan(0.52) = 0.5659 m. Stated here because it is the
+      # bound every velocity command has to respect, and a change to
+      # it should be visible in a diff rather than only in behaviour.
+      assert_in_delta OvcsVehicle.min_turning_radius(OvcsMini.geometry()), 0.5659, 0.001
+    end
+
+    test "an Ackermann vehicle cannot rotate on the spot" do
+      assert OvcsVehicle.max_yaw_rate(OvcsMini.geometry(), 0.0) == 0.0
+    end
+
+    test "the achievable yaw rate scales with speed" do
+      geometry = OvcsMini.geometry()
+      assert_in_delta OvcsVehicle.max_yaw_rate(geometry, 1.0), 1.767, 0.001
+      assert_in_delta OvcsVehicle.max_yaw_rate(geometry, 2.0), 3.534, 0.001
+    end
+  end
+end

--- a/vehicles/ovcs_mini/test/test_helper.exs
+++ b/vehicles/ovcs_mini/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Groundwork for the `ros2_control` port: `vms_core` can do kinematics without knowing which vehicle it's on.

## Why

Turning a velocity command into a steering angle is `atan(wheelbase * omega / v)` — identical arithmetic on every Ackermann vehicle, a different number on each one. That's the shape this repo already handles: vehicle-agnostic code in `vms_core`, vehicle-specific data at instantiation.

It just had nowhere to put the data, because **no Elixir code in the tree knew the vehicle's dimensions at all.** Wheelbase, track, wheel radius and steering limit existed only in `ovcs_mini`'s xacro.

The abandoned `ros2_control` branch hit exactly this and left placeholders:

```elixir
@min_angle -:math.pi()/4  # in rad to be fetched from composer ?
wheelbase = 1.0           # To be fetched from vehicle config, in meters
```

`geometry/0` is what those comments were asking for.

## What's in it

Optional callback returning measured quantities in **metres and radians**. Optional because a package that only reads a bus (`Obd2`) has none, and a vehicle whose numbers haven't been measured should omit it rather than guess — which is why `ovcs1` doesn't implement it yet.

Only *measured* quantities go in. `min_turning_radius/1` and `max_yaw_rate/2` are functions, because a stored derived value is one more copy to get wrong. `max_yaw_rate/2` returning `0.0` at a standstill isn't an edge case to paper over — an Ackermann vehicle can't rotate on the spot, and whatever consumes `/cmd_vel` has to decide what to do about that rather than discover it.

## The duplication is deliberate, and now checked

`ovcs_mini`'s numbers exist twice — `geometry/0` and `<xacro:property>` — and can't be shared: xacro can't read Elixir, and the simulator needs them at model-generation time.

Of the three ways out, this takes the cheapest: **duplicate and check**. Generating both from a third file adds build machinery; parsing someone else's XML for constants is fragile.

`vehicles/ovcs_mini/test/geometry_test.exs` asserts the two agree field by field, failing with both values and which file each came from. It also asserts the *set* of fields is fully covered, so adding one to `geometry/0` without covering it fails rather than silently reintroducing unchecked duplication.

Not hypothetical: this model shipped with a wheel radius wrong by 2×. It drove convincingly and reported nonsense, and `/odom` couldn't catch it because the plugin's arithmetic cancels the radius out.

**Verified in both directions** — perturbing the xacro fails, perturbing the Elixir fails:

```
OvcsMini.geometry()[:wheel_radius] is 0.0548, but the xacro says 0.1.
One of them is wrong; measure the vehicle rather than picking a side.
```

## Vehicles were never in the `mix test` matrix

The test job listed libraries, vms, infotainment and bridges — no vehicles — while **its own libmnl step already read `startsWith(matrix.project, 'vehicles/')`**. The special case existed for a matrix entry that didn't. A test in a vehicle package would never have run.

All three vehicles added; `ovcs1` and `obd2` have no tests yet and pass trivially.

## Also

- The vehicle template documents the callback with units, the measured-only rule, and a pointer to the geometry test. **Verified by generating a vehicle from it and compiling under `--warnings-as-errors`.**
- The worked examples in both helpers are real doctests now rather than prose that resembled one — an `iex>` block with `0.5659...` as its output would have broken the moment someone added `doctest OvcsVehicle`.

## Checks

```
libraries/ovcs_vehicle   fmt compile credo | 2 doctests, 3 tests, 0 failures
vehicles/ovcs_mini       fmt compile credo | 8 tests, 0 failures
```

## What this unblocks

The `ros2_control` port: `0x3A0 {linear, angular}` on CAN, `Ros2Control.Steering`/`.Throttle` in `vms_core` taking geometry as composer options rather than module attributes, the offset bug fixed, `ReceivedFrameWatcher` on the frame, and the bridge component replacing the Rclex-era teleop.
