### PR TITLE
deps(vms_dashboard): echarts 5 -> 6 to clear the XSS advisory

### DIFF
--- a/vms/dashboard/package-lock.json
+++ b/vms/dashboard/package-lock.json
@@ -10,10 +10,10 @@
       "dependencies": {
         "axios": "^1.6.7",
         "dotenv": "^16.4.5",
-        "echarts": "^5.5.0",
+        "echarts": "^6.1.0",
         "pinia": "^2.1.7",
         "vue": "^3.4.15",
-        "vue-echarts": "^6.6.9",
+        "vue-echarts": "^8.2.0",
         "vue-router": "^4.2.5"
       },
       "devDependencies": {
@@ -1902,13 +1902,13 @@
       "license": "MIT"
     },
     "node_modules/echarts": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
-      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.6.1"
+        "zrender": "6.1.0"
       }
     },
     "node_modules/editorconfig": {
@@ -3190,11 +3190,6 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
-    "node_modules/resize-detector": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/resize-detector/-/resize-detector-0.3.0.tgz",
-      "integrity": "sha512-R/tCuvuOHQ8o2boRP6vgx8hXCCy87H1eY9V5imBYeVNyNVpuL9ciReSccLj2gDcax9+2weXy3bc8Vv+NRXeEvQ=="
-    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -4070,53 +4065,13 @@
       "dev": true
     },
     "node_modules/vue-echarts": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-6.7.3.tgz",
-      "integrity": "sha512-vXLKpALFjbPphW9IfQPOVfb1KjGZ/f8qa/FZHi9lZIWzAnQC1DgnmEK3pJgEkyo6EP7UnX6Bv/V3Ke7p+qCNXA==",
-      "hasInstallScript": true,
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-8.2.0.tgz",
+      "integrity": "sha512-oUc4HgWYrUUac9AipF4Aas2R7CpGyZtSJk+pF/eFCZ47GkTmAly4mK2wx8lDg/q9Sd4gcLaoRGdGFXyXQUnjDQ==",
       "license": "MIT",
-      "dependencies": {
-        "resize-detector": "^0.3.0",
-        "vue-demi": "^0.13.11"
-      },
       "peerDependencies": {
-        "@vue/composition-api": "^1.0.5",
-        "@vue/runtime-core": "^3.0.0",
-        "echarts": "^5.4.1",
-        "vue": "^2.6.12 || ^3.1.1"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        },
-        "@vue/runtime-core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vue-echarts/node_modules/vue-demi": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
-      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
+        "echarts": "^6.0.0",
+        "vue": "^3.3.0"
       }
     },
     "node_modules/vue-router": {
@@ -4378,9 +4333,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
-      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"

--- a/vms/dashboard/package.json
+++ b/vms/dashboard/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "axios": "^1.6.7",
     "dotenv": "^16.4.5",
-    "echarts": "^5.5.0",
+    "echarts": "^6.1.0",
     "pinia": "^2.1.7",
     "vue": "^3.4.15",
-    "vue-echarts": "^6.6.9",
+    "vue-echarts": "^8.2.0",
     "vue-router": "^4.2.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Dependabot's only remaining open alert: medium-severity XSS in Apache ECharts, `< 6.1.0`.

## The cost is two majors, not a patch

The first patched version is **6.1.0** — a major — and `vue-echarts` 6.x peers on `echarts@^5`. So clearing the advisory means:

```
echarts      5.6.0 -> 6.1.0
vue-echarts  6.7.3 -> 8.2.0
```

`npm audit` is clean afterwards and the dashboard builds.

## Why the build isn't enough evidence

`test:unit` is a single scaffolded HelloWorld spec that touches nothing, so it says nothing about the charts.

Instead, every named import the dashboard actually uses was resolved against the new versions, and the registration call the chart makes on mount was made:

```
use, LineChart, TooltipComponent, TitleComponent, ToolboxComponent,
GridComponent, DataZoomComponent, LegendComponent, CanvasRenderer,
color, VChart, THEME_KEY
```

All twelve resolve, `use([...])` is accepted, and `color.lift` — the one function `App.vue` reaches for — is still a function. Two majors across two packages and nothing the dashboard touches moved.

## What this does not prove

**That the chart renders.** Nothing in this repo renders it in a test, and adding that means jsdom plus a canvas stub for echarts — a larger change than a dependency bump should carry.

The real-time line chart in the VMS dashboard is worth a look in a browser before trusting this on the vehicle. If it is broken, the fix is likely a small option-shape change rather than a revert.
