### PR TITLE
fix(ros_bridge): publish on the simulator's clock, and on /tf_static

### DIFF
--- a/bridges/ros_bridge/lib/ros2/rosgraph_msgs/msg/clock.ex
+++ b/bridges/ros_bridge/lib/ros2/rosgraph_msgs/msg/clock.ex
@@ -1,0 +1,20 @@
+defmodule Ros2.RosgraphMsgs.Msg.Clock do
+  @moduledoc """
+  ROS 2 `rosgraph_msgs/Clock`: a single `builtin_interfaces/Time`.
+
+  What a simulator publishes so every node can agree on a time that
+  is not the wall clock. `parse/1` only — nothing here is the
+  authority on time, it only follows one.
+  """
+  use Ros2.Common
+
+  alias Ros2.BuiltinInterfaces.Msg.Time
+
+  defstruct clock: %Time{}
+
+  def parse(body) when is_binary(body) do
+    with {:ok, clock, rest} <- Time.parse(body) do
+      {:ok, %__MODULE__{clock: clock}, rest}
+    end
+  end
+end

--- a/bridges/ros_bridge/lib/ros_bridge/clock.ex
+++ b/bridges/ros_bridge/lib/ros_bridge/clock.ex
@@ -1,0 +1,211 @@
+defmodule RosBridge.Clock do
+  @moduledoc """
+  What `use_sim_time` means for this bridge.
+
+  Every publisher stamps its output through
+  `RosBridge.Timing.time_message_for/1`, which projects a driver's
+  Erlang-monotonic capture time onto wall clock. On a vehicle that is
+  right. Against a simulator it is not: Gazebo owns the clock, starts
+  it at zero, and advances it with physics, so a wall-clock stamp is
+  most of two decades away from everything else on the graph.
+
+  That mattered less than it sounds until something consumed the
+  stamps. `RosBridge.Camera.Zenoh` documents the trade-off and
+  accepted it — pairing left and right frames only needs them to agree
+  with *each other*. Nav2 is the first consumer that needs them to
+  agree with **`/tf`**, and it does not: its costmap message filter
+  drops every point cloud with
+
+      the timestamp on the message is earlier than all the data in
+      the transform cache
+
+  ## How it follows the simulator
+
+  Not by passing simulator stamps through. `Frame.capture_ns` means
+  Erlang monotonic time everywhere in this bridge — `Timing` is built
+  on that and converts foreign clocks at the driver boundary — and
+  breaking that invariant to suit one consumer would trade a bounded
+  problem for an unbounded one.
+
+  Instead this tracks the *offset* between the two timescales. Each
+  `/clock` sample gives a simulator time and, read alongside it, a
+  local monotonic time; the difference is the offset, and any
+  monotonic timestamp projects through it. Drivers keep producing
+  monotonic time, `Timing` keeps being the only place that converts,
+  and the conversion simply targets a different clock.
+
+  ## Drift, and why it is small
+
+  The offset is exact only at the instant it was sampled. If the
+  simulator runs at other than real time the two clocks diverge
+  between samples, at a rate of `|1 - sim_rate|`. Gazebo publishes
+  `/clock` at its physics rate — hundreds of hertz — so the gap
+  between a sample and the capture it is used on is milliseconds, and
+  the error is a fraction of that. Far inside the jitter the stamps
+  already carry.
+
+  ## Reads are lock-free
+
+  `Timing` is called on every published message, so the offset lives
+  in `:atomics` rather than behind a `GenServer.call`. The reference
+  goes into `:persistent_term` exactly once, at start — a single
+  write, not a per-sample one, because a `:persistent_term` write
+  triggers a global scan and `/clock` arrives far too often for that.
+
+  Absent this process — the vehicle, and every test — `offset_ns/0`
+  answers `nil` and `Timing` keeps its wall-clock behaviour. Sim time
+  is opt-in, and nothing about the real path changes.
+
+  ## Why `init/1` blocks
+
+  It waits for the first `/clock` sample before returning, which holds
+  up the rest of the supervision tree for as long as that takes. That
+  is deliberate, and it is not about tidiness.
+
+  A single message published before the offset is known carries a
+  wall-clock stamp, and on `/tf` that is unrecoverable. `tf2` prunes
+  its buffer relative to its **newest** entry, so one transform
+  stamped 1.79e9 seconds discards every legitimate simulator-time
+  entry that follows it. The buffer ends up holding only the poisoned
+  entry, and every point cloud after that is rejected with
+
+      the timestamp on the message is earlier than all the data in
+      the transform cache
+
+  It does not recover, because the bad entry is decades in the future
+  and never ages out. Measured: the static-transform publisher won its
+  race against the first `/clock` sample by *zero milliseconds*, and
+  that was enough to make the costmaps ignore stereo for the whole
+  run.
+
+  So this is listed first among a vehicle's simulation components, and
+  blocking here means no publisher can emit a wall-clock stamp into a
+  simulator's graph. If no clock arrives within
+  the timeout below, it gives up loudly and lets the bridge run
+  on wall clock — degraded, but with a reason in the log rather than a
+  boot that never finishes.
+  """
+  use GenServer
+
+  alias Ros2.RosgraphMsgs.Msg.Clock, as: ClockMessage
+
+  require Logger
+
+  # Gazebo publishes /clock as soon as it is up, so this only ever
+  # elapses when the simulator is absent — which is worth reporting
+  # rather than hanging on.
+  @default_acquire_timeout_ms 10_000
+
+  @persistent_key __MODULE__
+  @offset_slot 1
+  @tracking_slot 2
+  @topic "clock"
+
+  @doc """
+  The monotonic-to-ROS-time offset in nanoseconds, or `nil` when this
+  bridge is not following a simulator clock.
+
+  `nil` is the answer on a vehicle and in tests, and it is what keeps
+  `RosBridge.Timing` on wall clock there.
+  """
+  @spec offset_ns() :: integer() | nil
+  def offset_ns do
+    case :persistent_term.get(@persistent_key, nil) do
+      nil ->
+        nil
+
+      atomics ->
+        case :atomics.get(atomics, @tracking_slot) do
+          0 -> nil
+          _tracking -> :atomics.get(atomics, @offset_slot)
+        end
+    end
+  end
+
+  @doc "Whether a simulator clock has been seen."
+  @spec following?() :: boolean()
+  def following?, do: offset_ns() != nil
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    timeout_ms = Keyword.get(List.wrap(opts), :acquire_timeout_ms, @default_acquire_timeout_ms)
+
+    atomics = :atomics.new(2, signed: true)
+    # Written once. Reads are on the publish path; writes are not.
+    :persistent_term.put(@persistent_key, atomics)
+
+    :ok = RosBridge.ZenohClient.subscribe(@topic, ClockMessage)
+    Logger.info("#{__MODULE__}: waiting for /#{@topic} before anything publishes a stamp")
+
+    samples = await_first_sample(atomics, timeout_ms)
+    {:ok, %{atomics: atomics, samples: samples}}
+  end
+
+  # A selective receive rather than a `handle_continue`: the point is
+  # that no *other* process gets to publish first, and anything after
+  # `init/1` returns is too late. See the moduledoc.
+  defp await_first_sample(atomics, timeout_ms) do
+    receive do
+      {:ros_message, {_key_expr, %ClockMessage{clock: clock}}} ->
+        record(atomics, clock)
+
+        Logger.info(
+          "#{__MODULE__}: simulator clock acquired at #{clock.sec}.#{clock.nanosec} — " <>
+            "stamps will line up with /tf and /odom."
+        )
+
+        1
+    after
+      timeout_ms ->
+        Logger.error(
+          "#{__MODULE__}: no /#{@topic} within #{timeout_ms} ms. Continuing on wall clock, " <>
+            "which against a simulator means every stamp is decades away from /tf and " <>
+            "consumers will reject them. Is the simulator running?"
+        )
+
+        0
+    end
+  end
+
+  @impl true
+  def handle_info({:ros_message, {_key_expr, %ClockMessage{clock: clock}}}, state) do
+    record(state.atomics, clock)
+    {:noreply, %{state | samples: state.samples + 1}}
+  end
+
+  def handle_info({:ros_message, {key_expr, message}}, state) do
+    Logger.warning("#{__MODULE__} unexpected message on #{key_expr}: #{inspect(message)}")
+
+    {:noreply, state}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  # Sampled as close together as the two reads allow; see the moduledoc
+  # on why the residual error does not matter.
+  defp record(atomics, clock) do
+    monotonic_now = System.monotonic_time(:nanosecond)
+    simulator_now = clock.sec * 1_000_000_000 + clock.nanosec
+
+    :atomics.put(atomics, @offset_slot, simulator_now - monotonic_now)
+    :atomics.put(atomics, @tracking_slot, 1)
+    :ok
+  end
+
+  @impl true
+  def terminate(_reason, _state) do
+    # Stop claiming to follow a clock nobody is reading any more; the
+    # next publisher call falls back to wall clock rather than using a
+    # frozen offset.
+    case :persistent_term.get(@persistent_key, nil) do
+      nil -> :ok
+      atomics -> :atomics.put(atomics, @tracking_slot, 0)
+    end
+
+    :ok
+  end
+end

--- a/bridges/ros_bridge/lib/ros_bridge/components.ex
+++ b/bridges/ros_bridge/lib/ros_bridge/components.ex
@@ -17,6 +17,11 @@ defmodule RosBridge.Components do
         * `:interval_ms` (default `1_000`)
     * `:joy_interpreter` — `RosBridge.Consumers.Joy` subscribing to
       `/joy` and forwarding axes onto the CAN bus. No opts.
+    * `:simulator_clock` — `RosBridge.Clock`, following `/clock` so
+      published stamps use simulator time rather than wall clock.
+      **Simulation only.** Without it every stamp is wall clock, which
+      is correct on a vehicle and wrong against Gazebo — see
+      `RosBridge.Clock` for what that breaks.
     * `:imu_publisher` — starts the named driver (any
       `OvcsDrivers.Imu` implementation) followed by
       `RosBridge.Publishers.Imu`. Opts:
@@ -67,6 +72,8 @@ defmodule RosBridge.Components do
        build: &heartbeat_message/1}
     ]
   end
+
+  def start(:simulator_clock, opts), do: [{RosBridge.Clock, opts}]
 
   def start(:joy_interpreter, _opts), do: [{RosBridge.Consumers.Joy, []}]
 

--- a/bridges/ros_bridge/lib/ros_bridge/publishers/static_transform.ex
+++ b/bridges/ros_bridge/lib/ros_bridge/publishers/static_transform.ex
@@ -19,13 +19,36 @@ defmodule RosBridge.Publishers.StaticTransform do
             translation: {x, y, z},          # metres, REP-103: x fwd, y left, z up
             rotation: {x, y, z, w}}          # quaternion, defaults to identity
 
-    * `:topic` (`"/tf"`), `:interval_ms` (`1000`).
+    * `:topic` (`"/tf_static"`), `:interval_ms` (`1000`).
 
-  Published on `/tf` rather than `/tf_static` on purpose. Static
-  transforms conventionally rely on TRANSIENT_LOCAL durability so a
-  late-joining viewer receives the latched message; `ZenohClient`
-  publishes volatile, so that viewer would wait forever. Republishing
-  at 1 Hz costs a few hundred bytes a second and always works.
+  Published on `/tf_static`, and *republished* at 1 Hz.
+
+  Both halves matter, and the first one was got wrong here once.
+  Static transforms conventionally rely on TRANSIENT_LOCAL durability
+  so a late-joining subscriber receives the latched message;
+  `ZenohClient` publishes volatile, so that subscriber would wait for
+  ever. Republishing fixes that.
+
+  But republishing on `/tf` — which is what this used to do — trades
+  one problem for a subtler one. A transform on `/tf` is *time
+  indexed*: `tf2` stores it against its stamp and interpolates
+  between samples, and will not extrapolate past the newest one. At
+  1 Hz that leaves a window up to a second wide in which any message
+  stamped after the latest transform cannot be transformed at all.
+  Nav2's costmaps hit it immediately:
+
+      Requested time 291.444 but the latest data is at time 291.217,
+      when looking up transform from frame [stereo_left] to frame
+      [odom]
+
+  227 ms newer than the transform, and the point cloud was dropped —
+  every one of them, for the whole run.
+
+  `/tf_static` has no such window: `tf2` keeps those transforms in a
+  separate buffer with no time index, so a lookup at *any* stamp
+  succeeds. Republishing them keeps the durability fix, and being
+  timeless removes the interpolation problem the previous choice
+  introduced.
   """
   use GenServer
 
@@ -36,7 +59,7 @@ defmodule RosBridge.Publishers.StaticTransform do
   alias Ros2.Tf2Msgs.Msg.TFMessage
   alias RosBridge.Timing
 
-  @default_topic "/tf"
+  @default_topic "/tf_static"
   @default_interval_ms 1_000
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)

--- a/bridges/ros_bridge/lib/ros_bridge/timing.ex
+++ b/bridges/ros_bridge/lib/ros_bridge/timing.ex
@@ -30,6 +30,19 @@ defmodule RosBridge.Timing do
   time. The offset drift between successive calls is on the
   order of nanoseconds — negligible compared to the
   millisecond-scale BEAM-scheduling jitter we're removing.
+
+  ## Wall clock is not always the target
+
+  Against a simulator it is the wrong clock entirely: Gazebo owns
+  time, starts it at zero and advances it with physics, so a
+  wall-clock stamp sits most of two decades away from `/tf` and
+  `/odom` and any consumer that compares them drops the message.
+
+  So `time_message_for/1` asks `RosBridge.Clock` which timescale to
+  target. With no simulator clock being followed — a vehicle, and
+  every test — the answer is `nil` and the wall-clock path above is
+  unchanged. Drivers are unaffected either way: they keep producing
+  Erlang monotonic time and this stays the only place that converts.
   """
 
   alias Ros2.BuiltinInterfaces.Msg.Time
@@ -63,17 +76,29 @@ defmodule RosBridge.Timing do
   end
 
   @doc """
+  Convert a monotonic capture timestamp into the timescale this
+  bridge is publishing on: simulator time when a `/clock` is being
+  followed, wall clock otherwise.
+  """
+  def ros_time_of(monotonic_nanoseconds) when is_integer(monotonic_nanoseconds) do
+    case RosBridge.Clock.offset_ns() do
+      nil -> wallclock_of(monotonic_nanoseconds)
+      offset -> monotonic_nanoseconds + offset
+    end
+  end
+
+  @doc """
   Build a `builtin_interfaces/Time` message from a monotonic
   capture timestamp. Most publishers want this directly — they
   have a `frame.capture_ns` in hand and need a `%Time{sec,
   nanosec}` to drop into a `std_msgs/Header`.
   """
   def time_message_for(monotonic_nanoseconds) do
-    wallclock_nanoseconds = wallclock_of(monotonic_nanoseconds)
+    nanoseconds = ros_time_of(monotonic_nanoseconds)
 
     %Time{
-      sec: div(wallclock_nanoseconds, 1_000_000_000),
-      nanosec: rem(wallclock_nanoseconds, 1_000_000_000)
+      sec: div(nanoseconds, 1_000_000_000),
+      nanosec: rem(nanoseconds, 1_000_000_000)
     }
   end
 end

--- a/bridges/ros_bridge/test/ros_bridge/clock_test.exs
+++ b/bridges/ros_bridge/test/ros_bridge/clock_test.exs
@@ -1,0 +1,159 @@
+defmodule RosBridge.ClockTest do
+  @moduledoc """
+  Tests for following a simulator clock.
+
+  The property that matters most is the *absence* of an effect: on a
+  vehicle, and in every other test in this suite, no `/clock` is being
+  followed and `RosBridge.Timing` must behave exactly as it did before
+  this existed. Sim time is opt-in, and a clock module that quietly
+  changed stamps on the real vehicle would be far worse than one that
+  did nothing.
+
+  `async: false`, because the offset lives in `:persistent_term` and
+  `:atomics` — process-independent by design, since it is read on
+  every published message and cannot afford a `GenServer.call`. That
+  makes it global state, so these tests own it exclusively and clean
+  up after themselves.
+  """
+  use ExUnit.Case, async: false
+
+  alias Ros2.RosgraphMsgs.Msg.Clock, as: ClockMessage
+  alias RosBridge.{Clock, Timing}
+
+  @persistent_key RosBridge.Clock
+
+  # Verbatim from `rclpy.serialization.serialize_message` on a Lyrical
+  # runtime, including the 4-byte CDR encapsulation header that
+  # `Ros2.RmwZenoh` strips before any `parse/1`.
+  @clock_hex "000100003a000000c0665326"
+
+  setup do
+    on_exit(fn -> :persistent_term.erase(@persistent_key) end)
+    :persistent_term.erase(@persistent_key)
+    :ok
+  end
+
+  defp body(hex) do
+    <<_encapsulation::binary-size(4), body::binary>> = Base.decode16!(hex, case: :lower)
+    body
+  end
+
+  # What `init/1` builds, without needing a ZenohClient to subscribe to.
+  defp tracking_state do
+    atomics = :atomics.new(2, signed: true)
+    :persistent_term.put(@persistent_key, atomics)
+    %{atomics: atomics, samples: 0}
+  end
+
+  defp clock_message(sec, nanosec) do
+    {:ros_message,
+     {"clock", %ClockMessage{clock: %Ros2.BuiltinInterfaces.Msg.Time{sec: sec, nanosec: nanosec}}}}
+  end
+
+  describe "parsing rosgraph_msgs/Clock" do
+    test "reads the simulator time out of real bytes" do
+      assert {:ok, %ClockMessage{clock: clock}, <<>>} = ClockMessage.parse(body(@clock_hex))
+      assert clock.sec == 58
+      assert clock.nanosec == 643_000_000
+    end
+  end
+
+  describe "with no simulator clock" do
+    test "there is no offset" do
+      refute Clock.following?()
+      assert Clock.offset_ns() == nil
+    end
+
+    test "Timing stays on wall clock" do
+      # The regression that would matter on the vehicle: stamps must
+      # still land near system time, not near zero.
+      monotonic = System.monotonic_time(:nanosecond)
+      stamped = Timing.ros_time_of(monotonic)
+      assert_in_delta stamped, System.system_time(:nanosecond), 1_000_000_000
+    end
+  end
+
+  describe "once a simulator clock arrives" do
+    test "the offset projects monotonic time onto simulator time" do
+      {:noreply, _state} = Clock.handle_info(clock_message(58, 643_000_000), tracking_state())
+
+      assert Clock.following?()
+
+      # A capture taken now should stamp at roughly the simulator time
+      # we just saw — not at 1.78e9 seconds.
+      stamped = Timing.ros_time_of(System.monotonic_time(:nanosecond))
+      assert_in_delta stamped, 58_643_000_000, 100_000_000
+    end
+
+    test "a stamp is nowhere near wall clock, which is the whole point" do
+      {:noreply, _state} = Clock.handle_info(clock_message(58, 0), tracking_state())
+
+      stamped = Timing.ros_time_of(System.monotonic_time(:nanosecond))
+      wall = System.system_time(:nanosecond)
+
+      assert abs(wall - stamped) > 1_000_000_000_000_000,
+             "simulator stamps should be ~two decades from wall clock, not adjacent to it"
+    end
+
+    test "the offset tracks a clock that keeps advancing" do
+      state = tracking_state()
+      {:noreply, state} = Clock.handle_info(clock_message(10, 0), state)
+      first = Clock.offset_ns()
+
+      {:noreply, _state} = Clock.handle_info(clock_message(20, 0), state)
+      second = Clock.offset_ns()
+
+      # Ten simulated seconds passed in near-zero real time, so the
+      # offset must have grown by about that much.
+      assert_in_delta second - first, 10_000_000_000, 100_000_000
+    end
+
+    test "a stamp fits builtin_interfaces/Time without wrapping" do
+      # `sec` is an int32. A wall-clock stamp is fine today but a
+      # simulator stamp being *negative* would mean the offset was
+      # applied the wrong way round, which is the classic sign error
+      # here.
+      {:noreply, _state} = Clock.handle_info(clock_message(58, 643_000_000), tracking_state())
+
+      time = Timing.time_message_for(System.monotonic_time(:nanosecond))
+      assert time.sec > 0
+      assert time.sec < 2_147_483_647
+      assert time.nanosec >= 0 and time.nanosec < 1_000_000_000
+    end
+  end
+
+  describe "shutting down" do
+    test "stops claiming to follow a clock, rather than freezing the offset" do
+      state = tracking_state()
+      {:noreply, state} = Clock.handle_info(clock_message(58, 0), state)
+      assert Clock.following?()
+
+      :ok = Clock.terminate(:shutdown, state)
+
+      refute Clock.following?(),
+             "a stopped clock left a frozen offset behind, so stamps would drift for ever"
+
+      # And Timing goes back to wall clock rather than using it.
+      stamped = Timing.ros_time_of(System.monotonic_time(:nanosecond))
+      assert_in_delta stamped, System.system_time(:nanosecond), 1_000_000_000
+    end
+  end
+
+  describe "unexpected input" do
+    test "a message for another topic does not disturb the offset" do
+      state = tracking_state()
+      {:noreply, state} = Clock.handle_info(clock_message(58, 0), state)
+      before = Clock.offset_ns()
+
+      {:noreply, _state} =
+        Clock.handle_info({:ros_message, {"something_else", %{unexpected: true}}}, state)
+
+      assert Clock.offset_ns() == before
+    end
+
+    test "a stray message is ignored rather than fatal" do
+      state = tracking_state()
+      assert {:noreply, ^state} = Clock.handle_info(:unplanned, state)
+    end
+  end
+end

--- a/vehicles/ovcs_mini/lib/ovcs_mini.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini.ex
@@ -159,6 +159,13 @@ defmodule OvcsMini do
       components:
         [
           :heartbeat,
+          # First, and only here. Gazebo owns the clock in simulation,
+          # so every stamp this bridge publishes has to be on
+          # simulator time or it will not line up with /tf and /odom —
+          # Nav2's costmaps drop point clouds that do not. On the
+          # vehicle there is no /clock and wall clock is correct, which
+          # is why this appears in no other configuration.
+          :simulator_clock,
           stereo_transforms(),
           stereo_component(RosBridge.Camera.Zenoh, :sim)
         ] ++ sim_detector()


### PR DESCRIPTION
Three defects, found by pointing Nav2's costmaps at the stereo point cloud and watching every message get dropped. Each is a genuine bug in its own right; the costmap was only what exposed them.

**This PR does not make obstacles appear in the costmap** — see the end.

## 1. Stamps were wall clock in a simulator

Every publisher stamps through `Timing.time_message_for/1`, which projects a driver's Erlang-monotonic capture time onto wall clock. On a vehicle that's right. Against Gazebo it isn't: the simulator owns time, starts it at zero and advances it with physics, so a wall-clock stamp sits most of two decades from `/tf` and `/odom`.

`RosBridge.Camera.Zenoh` already documented this and accepted it — pairing left and right frames only needs them to agree with *each other*. Nav2 is the first consumer that needs them to agree with **`/tf`**, so the accepted cost became a blocker.

`RosBridge.Clock` follows `/clock` and keeps a monotonic→simulator offset. Drivers go on producing monotonic time and `Timing` stays the only place that converts — it just converts to a different clock. Reads are on the publish path, so the offset lives in `:atomics` with the reference in `:persistent_term`, written once (a `:persistent_term` write triggers a global scan, and `/clock` arrives far too often for that).

Absent the process — **the vehicle, and every test** — `offset_ns/0` answers `nil` and nothing about the wall-clock path changes. Sim time is opt-in.

| | before | after |
|---|---|---|
| `/clock` | 38 | 38 |
| `/stereo/points` | **1788531117** | **39** |

## 2. One early message poisoned the transform cache permanently

`init/1` now blocks until the first `/clock` sample. That looks like fussiness and isn't.

`tf2` prunes its buffer relative to its **newest** entry. So a single transform stamped 1.79e9 discards every legitimate simulator-time entry that follows — permanently, because the bad entry is decades in the future and never ages out.

Not hypothetical. The static-transform publisher won its race against the first `/clock` sample by **zero milliseconds**:

```
16:34:35.833  put #1 on 0/tf            ← wall-clock stamp
16:34:35.833  simulator clock acquired
```

That was enough to make the costmaps ignore stereo for the whole run. Now:

```
16:46:11.975  simulator clock acquired
16:46:11.996  put #1 on 0/tf
```

There's a 10 s timeout: if no clock arrives it gives up loudly and runs on wall clock, rather than a boot that never finishes.

## 3. Static transforms were interpolatable

They were on `/tf` deliberately, to work around `ZenohClient` publishing volatile where TRANSIENT_LOCAL durability is conventional — a late subscriber would otherwise wait for ever, and republishing at 1 Hz fixes that.

But a transform on `/tf` is **time indexed**: `tf2` interpolates between samples and refuses to extrapolate past the newest. At 1 Hz that leaves a window up to a second wide where anything stamped after the latest transform can't be transformed at all. Asking tf2 directly:

```
Requested time 291.444 but the latest data is at time 291.217,
when looking up transform from frame [stereo_left] to frame [odom]
```

227 ms newer than the transform, and every point cloud dropped.

`/tf_static` has no such window — those live in a separate, untimed buffer — so republishing *there* keeps the durability fix and loses the interpolation problem it introduced. This helps the real vehicle too: any consumer needing per-message TF had the same latent gap.

## What this does not do

It does not make obstacles appear in the costmap.

The remaining symptom is point clouds stamped seconds behind simulator time, with Gazebo running at **0.77× real time** alongside SGBM. Whether that's pipeline latency, a queue, or something else **is not established**.

The likely read is a performance characteristic of running the whole stack on one workstation rather than a bug, and that a stereo-fed costmap may not be viable at 640×480 SGBM here. The voxel-layer config stays unmerged on `feat-nav2-stereo-costmap`: correct configuration, unproven end to end.

## Checks

```
bridges/ros_bridge   fmt compile credo | 203 tests, 0 failures
vehicles/ovcs_mini   fmt compile credo |   8 tests, 0 failures
```

`RosBridge.Clock` has 10 tests of its own, including that it does nothing when no simulator clock is present — the property that matters on the vehicle.
