### PR TITLE
fix(ros_bridge): make the clock deadline mean what it says, and run terminate

### DIFF
--- a/bridges/ros_bridge/lib/ros_bridge/camera/zenoh.ex
+++ b/bridges/ros_bridge/lib/ros_bridge/camera/zenoh.ex
@@ -44,10 +44,17 @@ defmodule RosBridge.Camera.Zenoh do
   passing it through would project to a wall-clock time nearly two
   decades wrong.
 
-  The cost is that outgoing headers carry arrival time rather than
-  simulation time, so they do not line up with `/clock`. Pairing is
-  unaffected: both sides are published together and land within a
-  millisecond of each other, far inside `:pair_tolerance_ms`.
+  That used to mean outgoing headers carried arrival time rather than
+  simulation time and so did not line up with `/clock`. It no longer
+  does: `RosBridge.Clock` keeps a monotonic-to-simulator offset, and
+  `RosBridge.Timing` projects through it, so arrival time lands on the
+  simulator's timescale without this driver having to pass a foreign
+  clock through. Frames stay on Erlang monotonic time here, which is
+  the invariant that made the conversion possible in one place.
+
+  Pairing was never affected either way: both sides are published
+  together and land within a millisecond of each other, far inside
+  `:pair_tolerance_ms`.
   """
   @behaviour RosBridge.Camera
 

--- a/bridges/ros_bridge/lib/ros_bridge/clock.ex
+++ b/bridges/ros_bridge/lib/ros_bridge/clock.ex
@@ -2,16 +2,23 @@ defmodule RosBridge.Clock do
   @moduledoc """
   What `use_sim_time` means for this bridge.
 
-  Every publisher stamps its output through
+  The stereo publishers stamp their output through
   `RosBridge.Timing.time_message_for/1`, which projects a driver's
   Erlang-monotonic capture time onto wall clock. On a vehicle that is
   right. Against a simulator it is not: Gazebo owns the clock, starts
   it at zero, and advances it with physics, so a wall-clock stamp is
   most of two decades away from everything else on the graph.
 
+  Not *every* publisher goes through `Timing`, which is worth knowing
+  before adding one to a simulation configuration:
+  `RosBridge.Publishers.Imu` builds its `%Time{}` from
+  `System.system_time/1` directly and so ignores this entirely. No
+  simulation configuration includes it today, so nothing is currently
+  wrong — but the invariant is positional rather than enforced.
+
   That mattered less than it sounds until something consumed the
-  stamps. `RosBridge.Camera.Zenoh` documents the trade-off and
-  accepted it — pairing left and right frames only needs them to agree
+  stamps. `RosBridge.Camera.Zenoh` used to document the trade-off and
+  accept it — pairing left and right frames only needs them to agree
   with *each other*. Nav2 is the first consumer that needs them to
   agree with **`/tf`**, and it does not: its costmap message filter
   drops every point cloud with
@@ -80,10 +87,27 @@ defmodule RosBridge.Clock do
 
   So this is listed first among a vehicle's simulation components, and
   blocking here means no publisher can emit a wall-clock stamp into a
-  simulator's graph. If no clock arrives within
-  the timeout below, it gives up loudly and lets the bridge run
-  on wall clock — degraded, but with a reason in the log rather than a
-  boot that never finishes.
+  simulator's graph.
+
+  ## Giving up is permanent, on purpose
+
+  If no clock arrives before the timeout, this stops following
+  `/clock` altogether — it unsubscribes, and a sample arriving later
+  is ignored.
+
+  That is deliberate and it is the uncomfortable choice. Switching to
+  simulator time *later* sounds more helpful and is worse: by then
+  wall-clock stamps are already in `tf2`'s buffer, and one of those
+  poisons it permanently for the reason above. Mixing the two
+  timescales in one run is the failure this module exists to prevent,
+  so a run that has started on wall clock finishes on wall clock.
+
+  Which makes the timeout a real deadline rather than a nicety, and
+  it is set accordingly: `docker compose up -d` returns long before
+  Gazebo has loaded a world, spawned the robot and started
+  `ros_gz_bridge` — the node that bridges `/clock` at all — so a
+  short deadline would fire during an ordinary cold boot. Override it
+  with `:acquire_timeout_ms` if a slower machine needs longer.
   """
   use GenServer
 
@@ -91,10 +115,11 @@ defmodule RosBridge.Clock do
 
   require Logger
 
-  # Gazebo publishes /clock as soon as it is up, so this only ever
-  # elapses when the simulator is absent — which is worth reporting
-  # rather than hanging on.
-  @default_acquire_timeout_ms 10_000
+  # A deadline, not a nicety — see the moduledoc. `docker compose up -d`
+  # returns before Gazebo has loaded a world and started the node that
+  # bridges /clock, so this has to outlast an ordinary cold boot. It
+  # only elapses when no simulator is coming.
+  @default_acquire_timeout_ms 60_000
 
   @persistent_key __MODULE__
   @offset_slot 1
@@ -132,49 +157,76 @@ defmodule RosBridge.Clock do
 
   @impl true
   def init(opts) do
-    timeout_ms = Keyword.get(List.wrap(opts), :acquire_timeout_ms, @default_acquire_timeout_ms)
+    # Keyword list from a plain component entry, map from one with
+    # options. `Map.new/1` takes either; `List.wrap/1` would turn a map
+    # into a one-element list and then fail.
+    opts = Map.new(opts || [])
+    timeout_ms = Map.get(opts, :acquire_timeout_ms, @default_acquire_timeout_ms)
+    # Injected so the lifecycle can be tested without a live
+    # ZenohClient — see the note on `terminate/2`.
+    subscriber = Map.get(opts, :subscriber, RosBridge.ZenohClient)
+
+    # So `terminate/2` actually runs. Without this a supervisor's
+    # ordinary `exit(pid, :shutdown)` skips it entirely, and the
+    # tracking flag below would survive this process.
+    Process.flag(:trap_exit, true)
 
     atomics = :atomics.new(2, signed: true)
     # Written once. Reads are on the publish path; writes are not.
     :persistent_term.put(@persistent_key, atomics)
 
-    :ok = RosBridge.ZenohClient.subscribe(@topic, ClockMessage)
+    :ok = subscriber.subscribe(@topic, ClockMessage)
     Logger.info("#{__MODULE__}: waiting for /#{@topic} before anything publishes a stamp")
 
-    samples = await_first_sample(atomics, timeout_ms)
-    {:ok, %{atomics: atomics, samples: samples}}
+    state = %{atomics: atomics, samples: 0, subscriber: subscriber, following: false}
+    {:ok, await_first_sample(state, timeout_ms)}
   end
 
   # A selective receive rather than a `handle_continue`: the point is
   # that no *other* process gets to publish first, and anything after
   # `init/1` returns is too late. See the moduledoc.
-  defp await_first_sample(atomics, timeout_ms) do
+  defp await_first_sample(state, timeout_ms) do
     receive do
       {:ros_message, {_key_expr, %ClockMessage{clock: clock}}} ->
-        record(atomics, clock)
+        record(state.atomics, clock)
 
         Logger.info(
           "#{__MODULE__}: simulator clock acquired at #{clock.sec}.#{clock.nanosec} — " <>
             "stamps will line up with /tf and /odom."
         )
 
-        1
+        %{state | samples: 1, following: true}
     after
       timeout_ms ->
+        # Stop listening, so a late sample cannot flip the timescale
+        # mid-run. See "Giving up is permanent" in the moduledoc.
+        :ok = state.subscriber.unsubscribe(@topic)
+
         Logger.error(
-          "#{__MODULE__}: no /#{@topic} within #{timeout_ms} ms. Continuing on wall clock, " <>
-            "which against a simulator means every stamp is decades away from /tf and " <>
-            "consumers will reject them. Is the simulator running?"
+          "#{__MODULE__}: no /#{@topic} within #{timeout_ms} ms — giving up and staying on " <>
+            "wall clock for the rest of this run, because switching timescales later " <>
+            "corrupts tf2's buffer for good. Against a simulator that means every stamp " <>
+            "is decades from /tf and consumers will reject them. Is the simulator running?"
         )
 
-        0
+        %{state | following: false}
     end
   end
 
   @impl true
-  def handle_info({:ros_message, {_key_expr, %ClockMessage{clock: clock}}}, state) do
+  def handle_info(
+        {:ros_message, {_key_expr, %ClockMessage{clock: clock}}},
+        %{following: true} = state
+      ) do
     record(state.atomics, clock)
     {:noreply, %{state | samples: state.samples + 1}}
+  end
+
+  # Arrived after the deadline, or after unsubscribing did not take
+  # effect immediately. Ignored rather than adopted — see the
+  # moduledoc.
+  def handle_info({:ros_message, {_key_expr, %ClockMessage{}}}, state) do
+    {:noreply, state}
   end
 
   def handle_info({:ros_message, {key_expr, message}}, state) do
@@ -196,11 +248,21 @@ defmodule RosBridge.Clock do
     :ok
   end
 
+  @doc """
+  Stop claiming to follow a clock nobody is updating any more.
+
+  Without this the tracking flag outlives the process, and every
+  publisher goes on projecting through an offset that is frozen at the
+  moment this stopped — silently drifting, since the simulator's clock
+  keeps moving and nothing is left to notice.
+
+  Reached only because `init/1` sets `:trap_exit`. A `GenServer` does
+  **not** get `terminate/2` from a supervisor's ordinary
+  `exit(pid, :shutdown)` otherwise, so without that flag this was
+  dead code that only the test exercised.
+  """
   @impl true
   def terminate(_reason, _state) do
-    # Stop claiming to follow a clock nobody is reading any more; the
-    # next publisher call falls back to wall clock rather than using a
-    # frozen offset.
     case :persistent_term.get(@persistent_key, nil) do
       nil -> :ok
       atomics -> :atomics.put(atomics, @tracking_slot, 0)

--- a/bridges/ros_bridge/lib/ros_bridge/components.ex
+++ b/bridges/ros_bridge/lib/ros_bridge/components.ex
@@ -30,7 +30,7 @@ defmodule RosBridge.Components do
         * `:topic`, `:frame_id`, `:publish_interval_ms` — forwarded
           to `RosBridge.Publishers.Imu` (see its defaults).
     * `:static_transforms` — publishes the vehicle's fixed frame
-      relationships on `/tf`. Opts: `:transforms` (required, a list of
+      relationships on `/tf_static`, republished at 1 Hz. Opts: `:transforms` (required, a list of
       `%{parent:, child:, translation: {x,y,z}, rotation: {x,y,z,w}}`),
       plus `:topic` and `:interval_ms`. Without it, frame ids in
       message headers are labels a consumer cannot resolve — see

--- a/bridges/ros_bridge/lib/ros_bridge/timing.ex
+++ b/bridges/ros_bridge/lib/ros_bridge/timing.ex
@@ -96,9 +96,18 @@ defmodule RosBridge.Timing do
   def time_message_for(monotonic_nanoseconds) do
     nanoseconds = ros_time_of(monotonic_nanoseconds)
 
+    # Floor division, not `div/2`. `div` and `rem` truncate toward
+    # zero, so a negative total gives a negative `nanosec` — and
+    # `Time.encode/1` writes that field as `little-unsigned-integer`,
+    # which *wraps* rather than raising: -30 ms becomes 4_264_967_296,
+    # a stamp 4.26 s in the future.
+    #
+    # Reachable now that simulator time exists. After a world reset
+    # `/clock` returns to ~0, and a frame captured just before that
+    # sample projects to a small negative number.
     %Time{
-      sec: div(nanoseconds, 1_000_000_000),
-      nanosec: rem(nanoseconds, 1_000_000_000)
+      sec: Integer.floor_div(nanoseconds, 1_000_000_000),
+      nanosec: Integer.mod(nanoseconds, 1_000_000_000)
     }
   end
 end

--- a/bridges/ros_bridge/test/ros_bridge/clock_test.exs
+++ b/bridges/ros_bridge/test/ros_bridge/clock_test.exs
@@ -1,3 +1,25 @@
+# `subscribe/2` is called from inside `Clock.init/1`, so `self()` there
+# is the Clock process itself — putting a sample in its mailbox before
+# the selective receive runs. That lets the real lifecycle be tested
+# without a live ZenohClient, and without poking at process state.
+defmodule RosBridge.ClockTest.AcquiringSubscriber do
+  alias Ros2.BuiltinInterfaces.Msg.Time
+  alias Ros2.RosgraphMsgs.Msg.Clock, as: ClockMessage
+
+  def subscribe(topic, _module) do
+    send(self(), {:ros_message, {topic, %ClockMessage{clock: %Time{sec: 58, nanosec: 0}}}})
+    :ok
+  end
+
+  def unsubscribe(_topic), do: :ok
+end
+
+defmodule RosBridge.ClockTest.SilentSubscriber do
+  # Never delivers, so `init/1` reaches its deadline.
+  def subscribe(_topic, _module), do: :ok
+  def unsubscribe(_topic), do: :ok
+end
+
 defmodule RosBridge.ClockTest do
   @moduledoc """
   Tests for following a simulator clock.
@@ -19,6 +41,7 @@ defmodule RosBridge.ClockTest do
 
   alias Ros2.RosgraphMsgs.Msg.Clock, as: ClockMessage
   alias RosBridge.{Clock, Timing}
+  alias RosBridge.ClockTest.{AcquiringSubscriber, SilentSubscriber}
 
   @persistent_key RosBridge.Clock
 
@@ -38,11 +61,14 @@ defmodule RosBridge.ClockTest do
     body
   end
 
-  # What `init/1` builds, without needing a ZenohClient to subscribe to.
+  # What `init/1` builds once it has acquired a clock, without needing
+  # a ZenohClient to subscribe to. `following: true` matters: samples
+  # are only adopted while following, so that a late one after the
+  # deadline cannot switch timescales mid-run.
   defp tracking_state do
     atomics = :atomics.new(2, signed: true)
     :persistent_term.put(@persistent_key, atomics)
-    %{atomics: atomics, samples: 0}
+    %{atomics: atomics, samples: 0, subscriber: SilentSubscriber, following: true}
   end
 
   defp clock_message(sec, nanosec) do
@@ -122,20 +148,69 @@ defmodule RosBridge.ClockTest do
     end
   end
 
-  describe "shutting down" do
-    test "stops claiming to follow a clock, rather than freezing the offset" do
-      state = tracking_state()
-      {:noreply, state} = Clock.handle_info(clock_message(58, 0), state)
+  describe "the real lifecycle, under a supervisor" do
+    # The first version of the shutdown test called `terminate/2` by
+    # hand, so it passed while production did nothing: a `GenServer`
+    # does not receive `terminate/2` from a supervisor's ordinary
+    # `exit(pid, :shutdown)` unless it traps exits, and `init/1` did
+    # not. Testing the callback tested the callback. These test the
+    # guarantee.
+    test "a sample delivered during init is adopted" do
+      start_supervised!({Clock, %{subscriber: AcquiringSubscriber, acquire_timeout_ms: 5_000}})
+
       assert Clock.following?()
 
-      :ok = Clock.terminate(:shutdown, state)
+      assert_in_delta Timing.ros_time_of(System.monotonic_time(:nanosecond)),
+                      58_000_000_000,
+                      100_000_000
+    end
+
+    test "a supervised stop stops the offset being used" do
+      start_supervised!({Clock, %{subscriber: AcquiringSubscriber, acquire_timeout_ms: 5_000}})
+      assert Clock.following?()
+
+      :ok = stop_supervised(Clock)
 
       refute Clock.following?(),
-             "a stopped clock left a frozen offset behind, so stamps would drift for ever"
+             "a stopped clock left a frozen offset behind, so every stamp would drift for ever"
 
-      # And Timing goes back to wall clock rather than using it.
-      stamped = Timing.ros_time_of(System.monotonic_time(:nanosecond))
-      assert_in_delta stamped, System.system_time(:nanosecond), 1_000_000_000
+      # And Timing is back on wall clock rather than using it.
+      assert_in_delta Timing.ros_time_of(System.monotonic_time(:nanosecond)),
+                      System.system_time(:nanosecond),
+                      1_000_000_000
+    end
+  end
+
+  describe "giving up is permanent" do
+    # The review finding this exists for: the deadline logged
+    # "continuing on wall clock" while the subscription stayed live, so
+    # a sample arriving later silently switched timescales mid-run —
+    # which is exactly the tf2-poisoning the blocking init prevents.
+    test "the deadline leaves it on wall clock" do
+      start_supervised!({Clock, %{subscriber: SilentSubscriber, acquire_timeout_ms: 5}})
+
+      refute Clock.following?()
+
+      assert_in_delta Timing.ros_time_of(System.monotonic_time(:nanosecond)),
+                      System.system_time(:nanosecond),
+                      1_000_000_000
+    end
+
+    test "a sample arriving after the deadline is ignored" do
+      start_supervised!({Clock, %{subscriber: SilentSubscriber, acquire_timeout_ms: 5}})
+      clock = Process.whereis(Clock)
+
+      send(
+        clock,
+        {:ros_message,
+         {"clock", %ClockMessage{clock: %Ros2.BuiltinInterfaces.Msg.Time{sec: 58, nanosec: 0}}}}
+      )
+
+      # Round-trip so the message above is definitely handled.
+      _ = :sys.get_state(clock)
+
+      refute Clock.following?(),
+             "a late /clock sample switched the timescale mid-run, which corrupts tf2 for good"
     end
   end
 


### PR DESCRIPTION
Follow-up to #57: two defects in the clock work, both of which
undermined the thing #57 exists to do.

## 1. The deadline lied

`await_first_sample/2` returned on timeout, logged *"continuing on wall
clock"*, and **left the `/clock` subscription live**. So a sample
arriving later reached `handle_info/2`, set the offset, and switched
the whole bridge to simulator time — silently, with no second log line
and `following?/0` now true.

That is precisely the failure the blocking `init` exists to prevent: by
then, wall-clock stamps are already in `tf2`'s buffer, and one of those
poisons it permanently — `tf2` prunes relative to its newest entry, and
a 1.79e9 stamp never ages out.

**Giving up is now permanent**: it unsubscribes, and a late sample is
ignored by a guard rather than adopted. A run that starts on wall clock
finishes on wall clock. Mixing timescales within one run is worse than
either alone.

Which makes the timeout a real deadline — and **10 s was far too short**
for one. `docker compose up -d` returns long before Gazebo has loaded a
world, spawned the robot and started `ros_gz_bridge`, the node that
publishes `/clock` at all. So the old value fired during an ordinary
cold boot, which is exactly when the silent switch would then happen.
**60 s**, overridable with `:acquire_timeout_ms`.

## 2. `terminate/2` was never called

No `Process.flag(:trap_exit, true)`, and a `GenServer` does not receive
`terminate/2` from a supervisor's ordinary `exit(pid, :shutdown)`. So
the "no frozen offset" guarantee was dead code: stopping or restarting
this child left tracking set and the last offset in `:persistent_term`,
and publishers went on projecting through an offset frozen at that
moment while the simulator's clock kept moving.

**The test passed because it called `Clock.terminate/2` by hand** — an
assertion on a callback instead of on a behaviour.

`init/1` now traps exits, and the test drives a real supervisor:
`start_supervised!` then `stop_supervised`.

**Verified in both directions:**

| mutation | result |
|---|---|
| remove `trap_exit` | fails — *"a stopped clock left a frozen offset behind"* (the old test passed) |
| remove the `following: true` guard | fails — *"a late /clock sample switched the timescale mid-run"* |

Testing the lifecycle needed a seam, so `:subscriber` is injectable
(default `ZenohClient`). The stub delivers its sample from inside
`subscribe/2`, which runs in the Clock's own process — so it lands in
the mailbox before the selective receive, with no poking at process
state.

Also fixed `Map.new(List.wrap(opts))`, which turned a map of options
into a one-element list and crashed `init/1`. Only reachable with
options, which nothing passed until these tests did.

## The four smaller ones

- **`div`/`rem` truncate toward zero**, so a negative ros time gave a
  negative `nanosec` — and `Time.encode/1` writes it as
  `little-unsigned-integer`, which **wraps** instead of raising: −30 ms
  became 4,264,967,296, a stamp 4.26 s in the future. Reachable after a
  world reset returns `/clock` to ~0 with a frame still in flight. Now
  `Integer.floor_div/2` and `Integer.mod/2`.
- "**Every** publisher stamps through `Timing`" was false —
  `Publishers.Imu` builds its `%Time{}` from `System.system_time/1`.
  Nothing is broken today (no simulation config includes it), but the
  invariant is positional rather than enforced; the moduledoc now says
  so.
- `components.ex` still advertised `/tf` for `:static_transforms` after
  the same diff changed it to `/tf_static`. It is the entry vehicle
  authors read.
- `camera/zenoh.ex` still documented the timestamp mismatch as an
  accepted cost — which this branch removes — and `RosBridge.Clock`
  cites that passage, so the two docs contradicted each other.

## Verification

```
206 tests, 0 failures
format + compile --warnings-as-errors + credo --strict: clean
```
