### PR TITLE
feat(ovcs_mini): a speed source from the hall sensor

### DIFF
--- a/bridges/ros_bridge/test/ros_bridge/zenoh_client_sample_test.exs
+++ b/bridges/ros_bridge/test/ros_bridge/zenoh_client_sample_test.exs
@@ -149,7 +149,9 @@ defmodule RosBridge.ZenohClientSampleTest do
       body = :binary.copy(<<0>>, 48)
       log = capture_log(fn -> assert {:noreply, _} = sample(state(Twist), body) end)
 
-      assert log == ""
+      # Other async tests log too, so only the surplus warning is ruled
+      # out, not every line captured in the window.
+      refute log =~ "unread"
       assert_received {:ros_message, {_key, %Twist{}}}
     end
   end

--- a/controllers/generic_controller/README.md
+++ b/controllers/generic_controller/README.md
@@ -143,3 +143,17 @@ Where
 | A1  | 0 |
 | A2  | 1 |
 | A3  | 2 |
+
+### Pulse counter
+
+| Physical Pin | OVCS Pin |
+| -------- | ------- |
+| A1  | 0 |
+
+Rising edges on the pin are counted by interrupt, and the frame `0x7X9`
+reports the running count (16 bits, wrapping) and the frequency in
+tenths of a hertz every 10 ms, only while the pin is enabled. The
+frequency is derived from the period between the last two edges, and
+decays to zero once no edge has arrived for a second, so 1 Hz is the
+slowest rate it reports. A1 is shared with analog input 0; when both
+are enabled in the adoption frame the pulse counter takes the pin.

--- a/controllers/generic_controller/README.md
+++ b/controllers/generic_controller/README.md
@@ -154,6 +154,7 @@ Rising edges on the pin are counted by interrupt, and the frame `0x7X9`
 reports the running count (16 bits, wrapping) and the frequency in
 tenths of a hertz every 10 ms, only while the pin is enabled. The
 frequency is derived from the period between the last two edges, and
-decays to zero once no edge has arrived for a second, so 1 Hz is the
-slowest rate it reports. A1 is shared with analog input 0; when both
+decays to zero once no edge has arrived for two seconds, so 0.5 Hz is
+the slowest rate it reports. Edges closer than 2 ms are ignored as
+chatter. A1 is shared with analog input 0; when both
 are enabled in the adoption frame the pulse counter takes the pin.

--- a/controllers/generic_controller/lib/Can/Can.cpp
+++ b/controllers/generic_controller/lib/Can/Can.cpp
@@ -65,6 +65,18 @@ void Can::emitdigitalAndAnalogPinsStatus(uint16_t digitalAndAnalogPinStatusesFra
 };
 
 
+// Both fields little-endian, matching the YAML.
+void Can::emitPulseCounterStatus(uint16_t pulseCounterStatusFrameId, uint16_t count, uint16_t frequencyDeciHz) {
+  CANMessage frame;
+  frame.id  = pulseCounterStatusFrameId;
+  frame.len = 4;
+  frame.data[0] = count & 0xFF;
+  frame.data[1] = count >> 8;
+  frame.data[2] = frequencyDeciHz & 0xFF;
+  frame.data[3] = frequencyDeciHz >> 8;
+  emit(frame);
+};
+
 PinStatus* Can::parseDigitalPinRequest() {
   static PinStatus digitalPinRequest[19] = {LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW, LOW};
   uint8_t pinNumber = 0;

--- a/controllers/generic_controller/lib/Can/Can.h
+++ b/controllers/generic_controller/lib/Can/Can.h
@@ -35,6 +35,7 @@ class Can {
     Vms parseVmsAliveFrame();
     VmsCommand parseVmsCommandFrame();
     void emitdigitalAndAnalogPinsStatus(uint16_t digitalAndAnalogPinsStatusFrameId, PinStatus digitalPinsStatus[19], uint16_t analogPinsStatus[3]);
+    void emitPulseCounterStatus(uint16_t pulseCounterStatusFrameId, uint16_t count, uint16_t frequencyDeciHz);
 
   private:
     uint8_t _aliveCounter;

--- a/controllers/generic_controller/lib/Configuration/Configuration.cpp
+++ b/controllers/generic_controller/lib/Configuration/Configuration.cpp
@@ -14,6 +14,7 @@ bool Configuration::load() {
     computeDigitalPins();
     computePwmPins();
     computeDacPin();
+    computePulsePin();
     computeAnalogPins();
     computeExternalPwms();
     DPRINTLN("> EEPROM configuration valid, ready!");
@@ -53,6 +54,7 @@ void Configuration::computeFrameIds() {
   _externalPwm1RequestFrameId        = shiftedId | EXTERNAL_PWM1_REQUEST_FRAME_ID_MASK;
   _externalPwm2RequestFrameId        = shiftedId | EXTERNAL_PWM2_REQUEST_FRAME_ID_MASK;
   _externalPwm3RequestFrameId        = shiftedId | EXTERNAL_PWM3_REQUEST_FRAME_ID_MASK;
+  _pulseCounterStatusFrameId         = shiftedId | PULSE_COUNTER_STATUS_FRAME_ID_MASK;
 };
 
 void Configuration::computeDigitalPins() {
@@ -101,8 +103,15 @@ void Configuration::computeDacPin() {
   _dacPin = DacPin(_rawConfiguration[6] >> 6 & 0b1, A0);
 };
 
+// A1 is shared with the pulse counter, which wins: a pin under an
+// interrupt is not also sampled as an analog input.
+void Configuration::computePulsePin() {
+  _pulsePin = PulsePin(_rawConfiguration[6] >> 2 & 0b1, A1);
+};
+
 void Configuration::computeAnalogPins() {
-  _analogPins[0] = AnalogPin(_rawConfiguration[6] >> 5 & 0b1, A1);
+  bool analogPin0Enabled = (_rawConfiguration[6] >> 5 & 0b1) && !_pulsePin.readable();
+  _analogPins[0] = AnalogPin(analogPin0Enabled, A1);
   _analogPins[1] = AnalogPin(_rawConfiguration[6] >> 4 & 0b1, A2);
   _analogPins[2] = AnalogPin(_rawConfiguration[6] >> 3 & 0b1, A3);
 };
@@ -119,6 +128,7 @@ void Configuration::initializePhysicalPins() {
   for (uint8_t i = 0; i < length; i++) {
     _digitalPins[i].initializePhysicalPin();
   }
+  _pulsePin.begin();
 };
 
 void Configuration::print() {
@@ -189,6 +199,9 @@ void Configuration::print() {
     Serial.print("> DAC Output Pin: ");
     _dacPin.writeable() ? Serial.print("ON") : Serial.print("OFF");
     Serial.println("");
+
+    Serial.print("> Pulse Counter Pin: ");
+    _pulsePin.readable() ? Serial.println("ON") : Serial.println("OFF");
 
     Serial.print("> Analog Input Pins: ");
     for(uint8_t i = 0; i < 3; i++) {

--- a/controllers/generic_controller/lib/Configuration/Configuration.cpp
+++ b/controllers/generic_controller/lib/Configuration/Configuration.cpp
@@ -103,14 +103,16 @@ void Configuration::computeDacPin() {
   _dacPin = DacPin(_rawConfiguration[6] >> 6 & 0b1, A0);
 };
 
-// A1 is shared with the pulse counter, which wins: a pin under an
-// interrupt is not also sampled as an analog input.
 void Configuration::computePulsePin() {
   _pulsePin = PulsePin(_rawConfiguration[6] >> 2 & 0b1, A1);
 };
 
+// A1 is shared with the pulse counter, which wins: a pin under an
+// interrupt is not also sampled as an analog input. Read from the raw
+// bit so this holds whatever order the compute functions run in.
 void Configuration::computeAnalogPins() {
-  bool analogPin0Enabled = (_rawConfiguration[6] >> 5 & 0b1) && !_pulsePin.readable();
+  bool pulsePinEnabled   = _rawConfiguration[6] >> 2 & 0b1;
+  bool analogPin0Enabled = (_rawConfiguration[6] >> 5 & 0b1) && !pulsePinEnabled;
   _analogPins[0] = AnalogPin(analogPin0Enabled, A1);
   _analogPins[1] = AnalogPin(_rawConfiguration[6] >> 4 & 0b1, A2);
   _analogPins[2] = AnalogPin(_rawConfiguration[6] >> 3 & 0b1, A3);

--- a/controllers/generic_controller/lib/Configuration/Configuration.cpp
+++ b/controllers/generic_controller/lib/Configuration/Configuration.cpp
@@ -108,11 +108,10 @@ void Configuration::computePulsePin() {
 };
 
 // A1 is shared with the pulse counter, which wins: a pin under an
-// interrupt is not also sampled as an analog input. Read from the raw
-// bit so this holds whatever order the compute functions run in.
+// interrupt is not also sampled as an analog input. `load()` computes
+// the pulse pin first.
 void Configuration::computeAnalogPins() {
-  bool pulsePinEnabled   = _rawConfiguration[6] >> 2 & 0b1;
-  bool analogPin0Enabled = (_rawConfiguration[6] >> 5 & 0b1) && !pulsePinEnabled;
+  bool analogPin0Enabled = (_rawConfiguration[6] >> 5 & 0b1) && !_pulsePin.readable();
   _analogPins[0] = AnalogPin(analogPin0Enabled, A1);
   _analogPins[1] = AnalogPin(_rawConfiguration[6] >> 4 & 0b1, A2);
   _analogPins[2] = AnalogPin(_rawConfiguration[6] >> 3 & 0b1, A3);

--- a/controllers/generic_controller/lib/Configuration/Configuration.h
+++ b/controllers/generic_controller/lib/Configuration/Configuration.h
@@ -6,6 +6,7 @@
 #include <PwmPin.h>
 #include <DacPin.h>
 #include <AnalogPin.h>
+#include <PulsePin.h>
 #include <EEPROM.h>
 #include <AbstractBoard.h>
 #include <AbstractCrc.h>
@@ -19,6 +20,7 @@
 #define EXTERNAL_PWM1_REQUEST_FRAME_ID_MASK 0x706
 #define EXTERNAL_PWM2_REQUEST_FRAME_ID_MASK 0x707
 #define EXTERNAL_PWM3_REQUEST_FRAME_ID_MASK 0x708
+#define PULSE_COUNTER_STATUS_FRAME_ID_MASK 0x709
 #define VMS_ALIVE_FRAME_ID 0x1A0
 #define VMS_COMMAND_FRAME_ID 0x1AA
 #define CONFIGURATION_EEPROM_ADDRESS 0
@@ -57,6 +59,7 @@ class Configuration {
     PwmPin _pwmPins [3];
     DacPin _dacPin;
     AnalogPin _analogPins [3];
+    PulsePin _pulsePin;
     ExternalPwm _externalPwms [4];
     uint16_t _aliveFrameId;
     uint16_t _digitalPinRequestFrameId;
@@ -66,6 +69,7 @@ class Configuration {
     uint16_t _externalPwm1RequestFrameId;
     uint16_t _externalPwm2RequestFrameId;
     uint16_t _externalPwm3RequestFrameId;
+    uint16_t _pulseCounterStatusFrameId;
     bool _expansionBoard1InUse;
     bool _expansionBoard2InUse;
 
@@ -105,6 +109,7 @@ class Configuration {
     void computePwmPins();
     void computeDacPin();
     void computeAnalogPins();
+    void computePulsePin();
     void computeExternalPwms();
     void print();
 };

--- a/controllers/generic_controller/lib/Controller/Controller.cpp
+++ b/controllers/generic_controller/lib/Controller/Controller.cpp
@@ -112,6 +112,15 @@ void Controller::emitPinStatuses() {
     PinStatus* digitalPinsStatus = readDigitalPins();
     uint16_t* analogPinsStatus = readAnalogPins();
     _can.emitdigitalAndAnalogPinsStatus(_configuration._digitalAndAnalogPinsStatusFrameId, digitalPinsStatus, analogPinsStatus);
+    // Only a controller with the pin enabled emits this frame; the
+    // others have no such frame declared on their bus.
+    if (_configuration._pulsePin.readable()) {
+      _can.emitPulseCounterStatus(
+        _configuration._pulseCounterStatusFrameId,
+        _configuration._pulsePin.count(),
+        _configuration._pulsePin.frequencyDeciHz()
+      );
+    }
   }
 };
 

--- a/controllers/generic_controller/lib/PulseCounter/PulseCounter.cpp
+++ b/controllers/generic_controller/lib/PulseCounter/PulseCounter.cpp
@@ -1,0 +1,30 @@
+#include <PulseCounter.h>
+
+void PulseCounter::recordEdge(uint32_t nowUs) {
+  if (_count > 0 || _lastEdgeUs != 0) {
+    uint32_t period = nowUs - _lastEdgeUs;
+    if (period < PULSE_MIN_PERIOD_US) {
+      return;
+    }
+    _periodUs = period;
+  }
+  _lastEdgeUs = nowUs;
+  _count++;
+};
+
+uint16_t PulseCounter::count() {
+  return _count;
+};
+
+uint16_t PulseCounter::frequencyDeciHz(uint32_t nowUs) {
+  if (_periodUs == 0) {
+    return 0;
+  }
+  uint32_t sinceLastEdge = nowUs - _lastEdgeUs;
+  if (sinceLastEdge > PULSE_TIMEOUT_US) {
+    return 0;
+  }
+  uint32_t period = _periodUs > sinceLastEdge ? _periodUs : sinceLastEdge;
+  uint32_t deciHz = 10000000UL / period;
+  return deciHz > 65535UL ? 65535 : (uint16_t)deciHz;
+};

--- a/controllers/generic_controller/lib/PulseCounter/PulseCounter.cpp
+++ b/controllers/generic_controller/lib/PulseCounter/PulseCounter.cpp
@@ -1,13 +1,15 @@
 #include <PulseCounter.h>
 
 void PulseCounter::recordEdge(uint32_t nowUs) {
-  if (_count > 0 || _lastEdgeUs != 0) {
+  if (_stopped) {
+    // The first edge after a stop measures the stop, not a period; the
+    // second one does.
+    _stopped = false;
+  } else {
     uint32_t period = nowUs - _lastEdgeUs;
     if (period < PULSE_MIN_PERIOD_US) {
       return;
     }
-    // The first edge after a stop measures the stop, not a period; the
-    // second one does.
     _periodUs = period > PULSE_TIMEOUT_US ? 0 : period;
   }
   _lastEdgeUs = nowUs;
@@ -22,15 +24,15 @@ uint16_t PulseCounter::frequencyDeciHz(uint32_t nowUs) {
   if (_periodUs == 0) {
     return 0;
   }
-  // An edge recorded after the caller sampled its clock reads as a
-  // negative gap; treat it as "just now" rather than as a wraparound.
-  int32_t gap = (int32_t)(nowUs - _lastEdgeUs);
-  uint32_t sinceLastEdge = gap < 0 ? 0 : (uint32_t)gap;
+  // Unsigned on purpose: the caller samples the clock with interrupts
+  // off, so an edge can never be newer than `nowUs`, and a stop long
+  // enough to wrap the clock must still read as a stop.
+  uint32_t sinceLastEdge = nowUs - _lastEdgeUs;
   if (sinceLastEdge > PULSE_TIMEOUT_US) {
     // Forget the period, or the stale pair would re-enter the window
     // every time the clock wraps (71.6 min) and report motion at rest.
-    // The next real edge measures a fresh period.
     _periodUs = 0;
+    _stopped  = true;
     return 0;
   }
   uint32_t period = _periodUs > sinceLastEdge ? _periodUs : sinceLastEdge;

--- a/controllers/generic_controller/lib/PulseCounter/PulseCounter.cpp
+++ b/controllers/generic_controller/lib/PulseCounter/PulseCounter.cpp
@@ -6,7 +6,9 @@ void PulseCounter::recordEdge(uint32_t nowUs) {
     if (period < PULSE_MIN_PERIOD_US) {
       return;
     }
-    _periodUs = period;
+    // The first edge after a stop measures the stop, not a period; the
+    // second one does.
+    _periodUs = period > PULSE_TIMEOUT_US ? 0 : period;
   }
   _lastEdgeUs = nowUs;
   _count++;
@@ -20,8 +22,15 @@ uint16_t PulseCounter::frequencyDeciHz(uint32_t nowUs) {
   if (_periodUs == 0) {
     return 0;
   }
-  uint32_t sinceLastEdge = nowUs - _lastEdgeUs;
+  // An edge recorded after the caller sampled its clock reads as a
+  // negative gap; treat it as "just now" rather than as a wraparound.
+  int32_t gap = (int32_t)(nowUs - _lastEdgeUs);
+  uint32_t sinceLastEdge = gap < 0 ? 0 : (uint32_t)gap;
   if (sinceLastEdge > PULSE_TIMEOUT_US) {
+    // Forget the period, or the stale pair would re-enter the window
+    // every time the clock wraps (71.6 min) and report motion at rest.
+    // The next real edge measures a fresh period.
+    _periodUs = 0;
     return 0;
   }
   uint32_t period = _periodUs > sinceLastEdge ? _periodUs : sinceLastEdge;

--- a/controllers/generic_controller/lib/PulseCounter/PulseCounter.h
+++ b/controllers/generic_controller/lib/PulseCounter/PulseCounter.h
@@ -1,0 +1,42 @@
+#ifndef PULSE_COUNTER_H
+#define PULSE_COUNTER_H
+
+#include <stdint.h>
+
+// No edge for this long reads as stopped. It also sets the lowest
+// frequency that can be reported: 1 Hz.
+#define PULSE_TIMEOUT_US 1000000UL
+// Edges closer than this are contact bounce or electrical noise, not a
+// hall sensor: 100 us is 10 kHz, far above anything a wheel produces.
+#define PULSE_MIN_PERIOD_US 100UL
+
+// Turns the edges of a pulse train into a frequency. Pure arithmetic on
+// the caller's clock, so the interrupt handler feeds it and the tests
+// drive it without hardware.
+class PulseCounter {
+  public:
+    PulseCounter() {
+      _count      = 0;
+      _lastEdgeUs = 0;
+      _periodUs   = 0;
+    };
+
+    // Called from the interrupt handler with the current micros().
+    void recordEdge(uint32_t nowUs);
+
+    // Edges since boot, wrapping at 65535.
+    uint16_t count();
+
+    // Tenths of a hertz, 0 when stopped. The period used is the longer
+    // of the last measured period and the time since the last edge, so
+    // a decelerating wheel reads lower on every tick instead of holding
+    // its last speed until the timeout.
+    uint16_t frequencyDeciHz(uint32_t nowUs);
+
+  private:
+    volatile uint16_t _count;
+    volatile uint32_t _lastEdgeUs;
+    volatile uint32_t _periodUs;
+};
+
+#endif

--- a/controllers/generic_controller/lib/PulseCounter/PulseCounter.h
+++ b/controllers/generic_controller/lib/PulseCounter/PulseCounter.h
@@ -3,12 +3,16 @@
 
 #include <stdint.h>
 
-// No edge for this long reads as stopped. It also sets the lowest
-// frequency that can be reported: 1 Hz.
-#define PULSE_TIMEOUT_US 1000000UL
-// Edges closer than this are contact bounce or electrical noise, not a
-// hall sensor: 100 us is 10 kHz, far above anything a wheel produces.
-#define PULSE_MIN_PERIOD_US 100UL
+// No edge for this long reads as stopped. It is also the lowest
+// frequency that can be reported, 0.5 Hz, and how long after the wheels
+// stop the speed reads zero. On the Mini's spur gear 0.5 Hz is about
+// 0.2 km/h at the wheel.
+#define PULSE_TIMEOUT_US 2000000UL
+// Edges closer than this are chatter, not a revolution. A hall switch
+// passed slowly through its threshold can toggle several times in a few
+// milliseconds; 2 ms is 500 Hz, still four times what the Mini's spur
+// gear reaches at full motor speed.
+#define PULSE_MIN_PERIOD_US 2000UL
 
 // Turns the edges of a pulse train into a frequency. Pure arithmetic on
 // the caller's clock, so the interrupt handler feeds it and the tests
@@ -30,7 +34,8 @@ class PulseCounter {
     // Tenths of a hertz, 0 when stopped. The period used is the longer
     // of the last measured period and the time since the last edge, so
     // a decelerating wheel reads lower on every tick instead of holding
-    // its last speed until the timeout.
+    // its last speed until the timeout. Reads `_lastEdgeUs` and
+    // `_periodUs` as a pair, so the caller must hold interrupts off.
     uint16_t frequencyDeciHz(uint32_t nowUs);
 
   private:

--- a/controllers/generic_controller/lib/PulseCounter/PulseCounter.h
+++ b/controllers/generic_controller/lib/PulseCounter/PulseCounter.h
@@ -23,6 +23,7 @@ class PulseCounter {
       _count      = 0;
       _lastEdgeUs = 0;
       _periodUs   = 0;
+      _stopped    = true;
     };
 
     // Called from the interrupt handler with the current micros().
@@ -42,6 +43,13 @@ class PulseCounter {
     volatile uint16_t _count;
     volatile uint32_t _lastEdgeUs;
     volatile uint32_t _periodUs;
+    // Set when the timeout fires (or before any edge), cleared by the
+    // next edge, which is then not paired with the stale `_lastEdgeUs`.
+    // The two guards below cover different clocks: the timeout branch
+    // only runs while the controller is READY, and `recordEdge` only
+    // sees edges, so neither alone survives a stop that spans a
+    // wraparound of the microsecond clock.
+    volatile bool _stopped;
 };
 
 #endif

--- a/controllers/generic_controller/lib/PulsePin/PulsePin.cpp
+++ b/controllers/generic_controller/lib/PulsePin/PulsePin.cpp
@@ -1,0 +1,41 @@
+#include <PulsePin.h>
+
+static PulseCounter pulseCounter0;
+
+static void pulsePin0Isr() {
+  pulseCounter0.recordEdge(micros());
+};
+
+bool PulsePin::readable() {
+  return _enabled;
+};
+
+void PulsePin::begin() {
+  if (readable()) {
+    pinMode(_physicalPin, INPUT);
+    attachInterrupt(digitalPinToInterrupt(_physicalPin), pulsePin0Isr, RISING);
+  }
+};
+
+// The counter's fields are written from the interrupt handler, so they
+// are read with interrupts off to get a consistent pair.
+uint16_t PulsePin::count() {
+  if (!readable()) {
+    return 0;
+  }
+  noInterrupts();
+  uint16_t count = pulseCounter0.count();
+  interrupts();
+  return count;
+};
+
+uint16_t PulsePin::frequencyDeciHz() {
+  if (!readable()) {
+    return 0;
+  }
+  uint32_t now = micros();
+  noInterrupts();
+  uint16_t frequency = pulseCounter0.frequencyDeciHz(now);
+  interrupts();
+  return frequency;
+};

--- a/controllers/generic_controller/lib/PulsePin/PulsePin.cpp
+++ b/controllers/generic_controller/lib/PulsePin/PulsePin.cpp
@@ -10,32 +10,34 @@ bool PulsePin::readable() {
   return _enabled;
 };
 
+// Pulled up: a hall sensor with an open-collector output only ever
+// pulls the line low, so without the pull-up it never rises and no edge
+// is counted. A push-pull sensor is unaffected.
 void PulsePin::begin() {
   if (readable()) {
-    pinMode(_physicalPin, INPUT);
+    pinMode(_physicalPin, INPUT_PULLUP);
     attachInterrupt(digitalPinToInterrupt(_physicalPin), pulsePin0Isr, RISING);
   }
 };
 
-// The counter's fields are written from the interrupt handler, so they
-// are read with interrupts off to get a consistent pair.
+// A single aligned 16-bit load is atomic on the Cortex-M4.
 uint16_t PulsePin::count() {
   if (!readable()) {
     return 0;
   }
-  noInterrupts();
-  uint16_t count = pulseCounter0.count();
-  interrupts();
-  return count;
+  return pulseCounter0.count();
 };
 
+// The period and the last edge are written together by the interrupt
+// handler, so they are read together with interrupts off. The clock
+// is sampled inside the guard too: an edge landing between the sample
+// and the guard would otherwise sit in the future.
 uint16_t PulsePin::frequencyDeciHz() {
   if (!readable()) {
     return 0;
   }
-  uint32_t now = micros();
   noInterrupts();
-  uint16_t frequency = pulseCounter0.frequencyDeciHz(now);
+  uint16_t frequency = pulseCounter0.frequencyDeciHz(micros());
   interrupts();
   return frequency;
 };

--- a/controllers/generic_controller/lib/PulsePin/PulsePin.cpp
+++ b/controllers/generic_controller/lib/PulsePin/PulsePin.cpp
@@ -17,6 +17,12 @@ void PulsePin::begin() {
   if (readable()) {
     pinMode(_physicalPin, INPUT_PULLUP);
     attachInterrupt(digitalPinToInterrupt(_physicalPin), pulsePin0Isr, RISING);
+  } else {
+    // A re-adoption that disables the pin runs this without a reboot,
+    // so the interrupt and the pull-up from the previous configuration
+    // have to be undone here.
+    detachInterrupt(digitalPinToInterrupt(_physicalPin));
+    pinMode(_physicalPin, INPUT);
   }
 };
 

--- a/controllers/generic_controller/lib/PulsePin/PulsePin.h
+++ b/controllers/generic_controller/lib/PulsePin/PulsePin.h
@@ -1,0 +1,22 @@
+#ifndef PULSE_PIN_H
+#define PULSE_PIN_H
+
+#include <Arduino.h>
+#include <OtherPin.h>
+#include <PulseCounter.h>
+
+// An input whose rising edges are counted by interrupt and reported as
+// a frequency. One instance is supported: attachInterrupt() needs a
+// free function, so the counter it feeds is a single static.
+class PulsePin: public OtherPin {
+  public:
+    PulsePin() {};
+    PulsePin(bool enabled, uint8_t physicalPin) : OtherPin(enabled, physicalPin) {};
+    bool readable();
+    // Configures the pin and attaches the interrupt. Safe to call again.
+    void begin();
+    uint16_t count();
+    uint16_t frequencyDeciHz();
+};
+
+#endif

--- a/controllers/generic_controller/test/PulseCounterTests.h
+++ b/controllers/generic_controller/test/PulseCounterTests.h
@@ -1,0 +1,87 @@
+#include <PulseCounter.h>
+
+namespace PulseCounterTests{
+    void testStoppedBeforeAnyEdge(){
+        PulseCounter counter;
+        TEST_ASSERT_EQUAL_UINT16(0, counter.count());
+        TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(5000000));
+    }
+
+    void testOneEdgeIsNotYetAFrequency(){
+        PulseCounter counter;
+        counter.recordEdge(1000000);
+        TEST_ASSERT_EQUAL_UINT16(1, counter.count());
+        TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(1000500));
+    }
+
+    void testFrequencyFromPeriod(){
+        // 20 ms between edges: 50 Hz, reported as 500 deci-hertz.
+        PulseCounter counter;
+        counter.recordEdge(1000000);
+        counter.recordEdge(1020000);
+        TEST_ASSERT_EQUAL_UINT16(2, counter.count());
+        TEST_ASSERT_EQUAL_UINT16(500, counter.frequencyDeciHz(1025000));
+    }
+
+    void testDecelerationReadsLowerBeforeTheTimeout(){
+        // Last period 20 ms, but 100 ms have passed since the last edge:
+        // the wheel cannot be turning faster than 10 Hz.
+        PulseCounter counter;
+        counter.recordEdge(1000000);
+        counter.recordEdge(1020000);
+        TEST_ASSERT_EQUAL_UINT16(100, counter.frequencyDeciHz(1120000));
+    }
+
+    void testStoppedAfterTheTimeout(){
+        PulseCounter counter;
+        counter.recordEdge(1000000);
+        counter.recordEdge(1020000);
+        TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(1020000 + PULSE_TIMEOUT_US + 1));
+    }
+
+    void testBounceIsIgnored(){
+        PulseCounter counter;
+        counter.recordEdge(1000000);
+        counter.recordEdge(1000010);
+        TEST_ASSERT_EQUAL_UINT16(1, counter.count());
+        counter.recordEdge(1020000);
+        TEST_ASSERT_EQUAL_UINT16(500, counter.frequencyDeciHz(1020000));
+    }
+
+    void testCountWrapsAt16Bits(){
+        PulseCounter counter;
+        for (uint32_t i = 0; i < 65537; i++) {
+            counter.recordEdge(i * 1000);
+        }
+        TEST_ASSERT_EQUAL_UINT16(1, counter.count());
+    }
+
+    void testFrequencySaturates(){
+        // 150 us period is 6666.6 Hz, above what 16 bits of deci-hertz hold.
+        PulseCounter counter;
+        counter.recordEdge(1000000);
+        counter.recordEdge(1000150);
+        TEST_ASSERT_EQUAL_UINT16(65535, counter.frequencyDeciHz(1000150));
+    }
+
+    void testMicrosWraparound(){
+        // micros() wraps every ~71 minutes; unsigned subtraction keeps
+        // the period right across it.
+        PulseCounter counter;
+        counter.recordEdge(0xFFFFFFF0);
+        counter.recordEdge(0x00004E10);  // 20000 us later
+        TEST_ASSERT_EQUAL_UINT16(500, counter.frequencyDeciHz(0x00004E10));
+    }
+
+    void run_tests(void){
+        RUN_TEST(testStoppedBeforeAnyEdge);
+        RUN_TEST(testOneEdgeIsNotYetAFrequency);
+        RUN_TEST(testFrequencyFromPeriod);
+        RUN_TEST(testDecelerationReadsLowerBeforeTheTimeout);
+        RUN_TEST(testStoppedAfterTheTimeout);
+        RUN_TEST(testBounceIsIgnored);
+        RUN_TEST(testCountWrapsAt16Bits);
+        RUN_TEST(testFrequencySaturates);
+        RUN_TEST(testMicrosWraparound);
+    }
+}

--- a/controllers/generic_controller/test/PulseCounterTests.h
+++ b/controllers/generic_controller/test/PulseCounterTests.h
@@ -39,29 +39,34 @@ namespace PulseCounterTests{
         TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(1020000 + PULSE_TIMEOUT_US + 1));
     }
 
-    void testBounceIsIgnored(){
+    void testChatterIsIgnored(){
+        // A slow pass through the threshold: three edges within 1.5 ms
+        // count as one revolution.
         PulseCounter counter;
         counter.recordEdge(1000000);
-        counter.recordEdge(1000010);
+        counter.recordEdge(1000500);
+        counter.recordEdge(1001500);
         TEST_ASSERT_EQUAL_UINT16(1, counter.count());
         counter.recordEdge(1020000);
+        TEST_ASSERT_EQUAL_UINT16(2, counter.count());
         TEST_ASSERT_EQUAL_UINT16(500, counter.frequencyDeciHz(1020000));
     }
 
     void testCountWrapsAt16Bits(){
         PulseCounter counter;
         for (uint32_t i = 0; i < 65537; i++) {
-            counter.recordEdge(i * 1000);
+            counter.recordEdge(i * 10000);
         }
         TEST_ASSERT_EQUAL_UINT16(1, counter.count());
     }
 
-    void testFrequencySaturates(){
-        // 150 us period is 6666.6 Hz, above what 16 bits of deci-hertz hold.
+    void testFastestAcceptedPeriod(){
+        // Exactly the minimum period is accepted and reads 500 Hz, well
+        // inside 16 bits of deci-hertz.
         PulseCounter counter;
         counter.recordEdge(1000000);
-        counter.recordEdge(1000150);
-        TEST_ASSERT_EQUAL_UINT16(65535, counter.frequencyDeciHz(1000150));
+        counter.recordEdge(1000000 + PULSE_MIN_PERIOD_US);
+        TEST_ASSERT_EQUAL_UINT16(5000, counter.frequencyDeciHz(1000000 + PULSE_MIN_PERIOD_US));
     }
 
     void testMicrosWraparound(){
@@ -73,15 +78,41 @@ namespace PulseCounterTests{
         TEST_ASSERT_EQUAL_UINT16(500, counter.frequencyDeciHz(0x00004E10));
     }
 
+    void testEdgeAfterTheClockSampleIsNotAWraparound(){
+        // The clock was read one microsecond before the last edge landed.
+        PulseCounter counter;
+        counter.recordEdge(1000000);
+        counter.recordEdge(1020000);
+        TEST_ASSERT_EQUAL_UINT16(500, counter.frequencyDeciHz(1019999));
+    }
+
+    void testStaysStoppedAcrossAClockWraparound(){
+        // Parked for 71.6 minutes: the stale pair must not re-enter the
+        // timeout window when the clock comes back around.
+        PulseCounter counter;
+        counter.recordEdge(1000000);
+        counter.recordEdge(1020000);
+        TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(1020000 + PULSE_TIMEOUT_US + 1));
+        TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(1030000));
+        // The first edge after a stop measures the stop, not a period;
+        // the second one starts a fresh measurement.
+        counter.recordEdge(4000000);
+        TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(4000500));
+        counter.recordEdge(4020000);
+        TEST_ASSERT_EQUAL_UINT16(500, counter.frequencyDeciHz(4020000));
+    }
+
     void run_tests(void){
+        RUN_TEST(testEdgeAfterTheClockSampleIsNotAWraparound);
+        RUN_TEST(testStaysStoppedAcrossAClockWraparound);
         RUN_TEST(testStoppedBeforeAnyEdge);
         RUN_TEST(testOneEdgeIsNotYetAFrequency);
         RUN_TEST(testFrequencyFromPeriod);
         RUN_TEST(testDecelerationReadsLowerBeforeTheTimeout);
         RUN_TEST(testStoppedAfterTheTimeout);
-        RUN_TEST(testBounceIsIgnored);
+        RUN_TEST(testChatterIsIgnored);
         RUN_TEST(testCountWrapsAt16Bits);
-        RUN_TEST(testFrequencySaturates);
+        RUN_TEST(testFastestAcceptedPeriod);
         RUN_TEST(testMicrosWraparound);
     }
 }

--- a/controllers/generic_controller/test/PulseCounterTests.h
+++ b/controllers/generic_controller/test/PulseCounterTests.h
@@ -78,12 +78,27 @@ namespace PulseCounterTests{
         TEST_ASSERT_EQUAL_UINT16(500, counter.frequencyDeciHz(0x00004E10));
     }
 
-    void testEdgeAfterTheClockSampleIsNotAWraparound(){
-        // The clock was read one microsecond before the last edge landed.
+    void testLongStopReadsAsStoppedAcrossTheWrap(){
+        // Wheel turning, then the controller leaves READY so the timeout
+        // is never evaluated, the wheel stops, and READY returns 50
+        // minutes later: the wrapped gap must read as a stop, not as
+        // the old speed.
         PulseCounter counter;
         counter.recordEdge(1000000);
         counter.recordEdge(1020000);
-        TEST_ASSERT_EQUAL_UINT16(500, counter.frequencyDeciHz(1019999));
+        TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(1020000 + 3000000000UL));
+    }
+
+    void testOneEdgeAfterAWrappedStopIsNotMotion(){
+        // Parked past a clock wraparound, then a single nudge lands where
+        // the wrapped gap would pass for a real period.
+        PulseCounter counter;
+        counter.recordEdge(1000000);
+        counter.recordEdge(1020000);
+        TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(1020000 + PULSE_TIMEOUT_US + 1));
+        counter.recordEdge(1020000 + 10000);  // 2^32 + 10 ms later, modulo 2^32
+        TEST_ASSERT_EQUAL_UINT16(3, counter.count());
+        TEST_ASSERT_EQUAL_UINT16(0, counter.frequencyDeciHz(1020000 + 10500));
     }
 
     void testStaysStoppedAcrossAClockWraparound(){
@@ -103,7 +118,8 @@ namespace PulseCounterTests{
     }
 
     void run_tests(void){
-        RUN_TEST(testEdgeAfterTheClockSampleIsNotAWraparound);
+        RUN_TEST(testLongStopReadsAsStoppedAcrossTheWrap);
+        RUN_TEST(testOneEdgeAfterAWrappedStopIsNotMotion);
         RUN_TEST(testStaysStoppedAcrossAClockWraparound);
         RUN_TEST(testStoppedBeforeAnyEdge);
         RUN_TEST(testOneEdgeIsNotYetAFrequency);

--- a/controllers/generic_controller/test/test_main.cpp
+++ b/controllers/generic_controller/test/test_main.cpp
@@ -8,6 +8,7 @@ using namespace fakeit;
 #include <AnalogPinTests.h>
 #include <AdoptionButtonTests.h>
 #include <DigitalPinTests.h>
+#include <PulseCounterTests.h>
 
 
 #define RUN_TEST_GROUP(TEST) \
@@ -32,5 +33,6 @@ int main()
   RUN_TEST_GROUP(AnalogPinTests);
   RUN_TEST_GROUP(AdoptionButtonTests);
   RUN_TEST_GROUP(DigitalPinTests);
+  RUN_TEST_GROUP(PulseCounterTests);
   return UNITY_END();
 }

--- a/docs/hardware_architecture.md
+++ b/docs/hardware_architecture.md
@@ -201,7 +201,7 @@ The OVCS Mini uses the same software stack on a Traxxas 4WD RC car chassis:
 | Controller | Arduino R4 Minima (single "main" controller) |
 | Motor | Traxxas brushless motor (controlled via external PWM) |
 | Steering | Traxxas servo (controlled via external PWM) |
-| Motor speed | Hall effect sensor on the main controller's A0, read as an analog sample; no pulse counting yet, so no speed signal |
+| Motor speed | Hall effect sensor on the main controller's A1, counted by interrupt and reported as a frequency on `0x709` |
 | Radio Control | ExpressLRS receiver via Radio Control Bridge (RPi 3A) |
 
 The OVCS Mini uses a single CAN bus (`ovcs` at 500 kbps) since there are no third-party automotive components requiring isolation.

--- a/docs/ros2_integration.md
+++ b/docs/ros2_integration.md
@@ -355,10 +355,10 @@ vehicle it is driving.
 two independent switches on the RC transmitter because *authority* and
 *autonomy* are different questions:
 
-| Channel | Component | Values | Answers |
+| Component | Values | Answers | Channel (Mini) |
 |---|---|---|---|
-| 3 | `RadioControl.RequestedControlLevel` | `:manual / :radio / :ros` | who has authority |
-| 5 | `RadioControl.RequestedRosCommander` | `:teleop / :autonomous` | which ROS node, when ROS does |
+| `RadioControl.RequestedControlLevel` | `:manual / :radio / :ros` | who has authority | 6 |
+| `RadioControl.RequestedRosCommander` | `:teleop / :autonomous` | which ROS node, when ROS does | 5 |
 
 `:ros` means "commands come from the ROS bridge". It does not mean the
 car is driving itself — a human on a gamepad and a planner reach the

--- a/docs/testing_generic_controllers.md
+++ b/docs/testing_generic_controllers.md
@@ -70,7 +70,19 @@ Digital readbacks and analog inputs are reported on `0x7X4` every 10 ms:
 candump can0,704:7FF
 ```
 
-The frame layout is in
+A controller with its pulse counter enabled also reports the count and
+frequency of the edges on A1 on `0x7X9`, every 10 ms:
+
+```sh
+candump can0,709:7FF
+```
+
+Bytes 0-1 are the count and bytes 2-3 the frequency in tenths of a
+hertz, both little-endian. A wheel turned by hand should step the count
+and show a frequency that falls back to zero within a second of
+stopping.
+
+The frame layouts are in
 [`controllers/generic_controller/README.md`](../controllers/generic_controller/README.md).
 
 ## Troubleshooting

--- a/docs/testing_generic_controllers.md
+++ b/docs/testing_generic_controllers.md
@@ -79,7 +79,7 @@ candump can0,709:7FF
 
 Bytes 0-1 are the count and bytes 2-3 the frequency in tenths of a
 hertz, both little-endian. A wheel turned by hand should step the count
-and show a frequency that falls back to zero within a second of
+and show a frequency that falls back to zero within two seconds of
 stopping.
 
 The frame layouts are in

--- a/docs/vehicle_parameterisation.md
+++ b/docs/vehicle_parameterisation.md
@@ -197,10 +197,13 @@ remsh / `./ovcs attach` flow.
 reads two independent switches on the RC transmitter, because
 authority and autonomy are different questions:
 
-| Component | Values | Channel on Mini | Channel on OVCS1 |
-|---|---|---|---|
-| `OVCS.RadioControl.RequestedControlLevel` | `:manual` / `:radio` / `:ros` | 6 | 3 |
-| `OVCS.RadioControl.RequestedRosCommander` | `:teleop` / `:autonomous` | 5 | not wired |
+| Component | Values |
+|---|---|
+| `OVCS.RadioControl.RequestedControlLevel` | `:manual` / `:radio` / `:ros` |
+| `OVCS.RadioControl.RequestedRosCommander` | `:teleop` / `:autonomous` |
+
+Which transmitter channel each one reads is per vehicle; the layout
+table below is the single place that records it.
 
 `:ros` means the vehicle takes its commands from the ROS bridge. It
 does **not** mean the vehicle is driving itself: a human on a gamepad
@@ -231,12 +234,14 @@ Switch positions are 1000, 1500 and 2000 µs with a margin of 100. A
 position outside every margin falls back to the safe one: `:manual` for
 the level, `:teleop` for the commander, `:forward` for direction.
 
-The Mini's link is ExpressLRS, and that fixes part of the layout:
-channel 5 is the link's arm channel, sent with every packet as a
-2-position value of 1000 or 2000 whatever switch drives it, so it can
-never carry a middle position. Channels 6 to 11 are 3-bit in the
-default Hybrid switch mode and do give 1000, 1500 and 2000. That is why
-the three-position level is on 6 and the two-position commander on 5.
+The Mini's link is ExpressLRS in MAVLink link mode, which forces the
+Hybrid switch mode, and that fixes part of the layout: channel 5 is the
+link's arm channel, sent with every packet as a 2-position value of
+1000 or 2000 whatever switch drives it, so it can never carry a middle
+position. In Hybrid mode channels 6 to 11 are 3-bit and do give 1000,
+1500 and 2000; of those only 6 to 8 reach the bus, since `0x2A1`
+carries channels 5 to 8. That is why the three-position level is on 6
+and the two-position commander on 5.
 
 ### The source maps
 
@@ -268,10 +273,25 @@ receiver: `radio_control_bridge_config(:host)` declares no components,
 so nothing emits `0x2A1`/`0x2A0` and the level never leaves `:manual`.
 Joystick input still reaches `0x2B0`/`0x2B1` and is discarded.
 
-So a bench session needs the switches synthesised. `0x2A0` carries
-channels 1-4 as little-endian `uint16`, two bytes each; `0x2A1`
-carries 5-8 the same way. 1500 is `DC05`, 2000 is `D007`, 1000 is
-`E803`:
+There is no controller on the host either, so nothing emits the pulse
+counter frame `0x709`. The generic controller publishes the pulse
+frequency as nil while that frame is dead, `Traxxas.Motor` publishes a
+nil speed, and the manager treats an unknown speed as "not a
+standstill": every mode change is refused with `:speed_unknown`. So a
+bench session needs two things synthesised, a speed and the switches.
+
+The speed first, and it has to be a stream: the frame watcher needs
+several on-time frames to declare `0x709` alive and drops it again as
+soon as they stop. Leave this running in its own terminal; a count and
+a frequency of zero is a stationary vehicle:
+
+```bash
+cangen vcan0 -I 709 -L 4 -D 00000000 -g 10
+```
+
+Then the switches. `0x2A0` carries channels 1-4 as little-endian
+`uint16`, two bytes each; `0x2A1` carries 5-8 the same way. 1500 is
+`DC05`, 2000 is `D007`, 1000 is `E803`:
 
 ```bash
 # Steering and throttle centred (channels 1 and 2)
@@ -285,17 +305,18 @@ cansend vcan0 2A1#E803DC0500000000
 cansend vcan0 2A1#E803D00700000000
 
 # Optional: hand it to the planner rather than the gamepad
-# (channel 5 = 2000). Needs a standstill, which the host always is.
+# (channel 5 = 2000). Needs a standstill, which the zero speed
+# stream above provides.
 cansend vcan0 2A1#D007D00700000000
 ```
 
 Channels 7 and 8 read as 0 in these frames, which is outside every
-switch margin and therefore the safe fallback. The frames above are the
-Mini's layout; on OVCS1 the level is channel 3, in `0x2A0`.
+switch margin and therefore the safe fallback. The frames are the
+Mini's layout; the table above has the other vehicles'.
 
-`ready_to_drive` is hardcoded `true` on Mini (`OvcsMini.Vms`), so
-nothing else is needed there. On a vehicle whose `ready_to_drive`
-comes from contactors or an inverter, that has to be true as well.
+`ready_to_drive` is hardcoded `true` on Mini (`OvcsMini.Vms`). On a
+vehicle whose `ready_to_drive` comes from contactors or an inverter,
+that has to be true as well.
 
 ## Host dev vs. deployed
 

--- a/docs/vehicle_parameterisation.md
+++ b/docs/vehicle_parameterisation.md
@@ -197,16 +197,16 @@ remsh / `./ovcs attach` flow.
 reads two independent switches on the RC transmitter, because
 authority and autonomy are different questions:
 
-| Channel | Component | Values |
-|---|---|---|
-| 3 | `OVCS.RadioControl.RequestedControlLevel` | `:manual` / `:radio` / `:ros` |
-| 5 | `OVCS.RadioControl.RequestedRosCommander` | `:teleop` / `:autonomous` |
+| Component | Values | Channel on Mini | Channel on OVCS1 |
+|---|---|---|---|
+| `OVCS.RadioControl.RequestedControlLevel` | `:manual` / `:radio` / `:ros` | 6 | 3 |
+| `OVCS.RadioControl.RequestedRosCommander` | `:teleop` / `:autonomous` | 5 | not wired |
 
 `:ros` means the vehicle takes its commands from the ROS bridge. It
 does **not** mean the vehicle is driving itself: a human on a gamepad
 and a planner reach the VMS over the same topics and the same CAN
-frames. Which of them has the wheel is channel 5's answer, and it is
-why the level is named `:ros` rather than `:autonomous`.
+frames. Which of them has the wheel is the commander switch's answer,
+and it is why the level is named `:ros` rather than `:autonomous`.
 
 Both switches only *request*. The manager decides, and refuses moves
 that are unsafe — in motion, not ready to drive, or while a fault has
@@ -214,16 +214,29 @@ forced a lower level. `:ros` is reachable only from `:radio`, so
 getting there is two deliberate throws with the middle position in
 between. A request it cannot honour is logged once, with the reason.
 
-The full channel convention, shared by every vehicle so a transmitter
-set up for one reads the same way on another:
+The full channel layout per vehicle. Channel numbers are the
+transmitter's own: the radio control bridge copies the receiver's
+channels 1-8 onto `0x2A0` and `0x2A1` unchanged, and each composer
+names the channel every component reads.
 
-| Channel | Purpose |
-|---|---|
-| 1 | Steering |
-| 2 | Throttle (and `radio_breaking`, the human takeover) |
-| 3 | Control level |
-| 4 | Direction (OVCS1; unused on Mini) |
-| 5 | ROS commander |
+| Purpose | Mini | OVCS1 |
+|---|---|---|
+| Steering | 1 | 1 |
+| Throttle (and `radio_breaking`, the human takeover) | 2 | 2 |
+| Control level | 6 | 3 |
+| Direction | 7 (published, no actuator reads it) | 4 |
+| ROS commander | 5 | not wired |
+
+Switch positions are 1000, 1500 and 2000 µs with a margin of 100. A
+position outside every margin falls back to the safe one: `:manual` for
+the level, `:teleop` for the commander, `:forward` for direction.
+
+The Mini's link is ExpressLRS, and that fixes part of the layout:
+channel 5 is the link's arm channel, sent with every packet as a
+2-position value of 1000 or 2000 whatever switch drives it, so it can
+never carry a middle position. Channels 6 to 11 are 3-bit in the
+default Hybrid switch mode and do give 1000, 1500 and 2000. That is why
+the three-position level is on 6 and the two-position commander on 5.
 
 ### The source maps
 
@@ -250,7 +263,7 @@ nobody asked for. Such a vehicle also omits
 
 `Managers.ControlLevel` starts in `default_control_level` — `:manual`
 on OVCS Mini, where every source is `nil`, so **nothing commands the
-vehicle until channel 3 says otherwise**. On the host there is no RC
+vehicle until channel 6 says otherwise**. On the host there is no RC
 receiver: `radio_control_bridge_config(:host)` declares no components,
 so nothing emits `0x2A1`/`0x2A0` and the level never leaves `:manual`.
 Joystick input still reaches `0x2B0`/`0x2B1` and is discarded.
@@ -261,17 +274,24 @@ carries 5-8 the same way. 1500 is `DC05`, 2000 is `D007`, 1000 is
 `E803`:
 
 ```bash
-# Steering and throttle centred, level -> :radio (channel 3 = 1500)
-cansend vcan0 2A0#DC05DC05DC050000
+# Steering and throttle centred (channels 1 and 2)
+cansend vcan0 2A0#DC05DC0500000000
 
-# ... then level -> :ros (channel 3 = 2000). Two steps, in this order:
+# Level -> :radio (channel 6 = 1500; channel 5 = 1000 keeps :teleop)
+cansend vcan0 2A1#E803DC0500000000
+
+# ... then level -> :ros (channel 6 = 2000). Two steps, in this order:
 # :ros is only reachable from :radio.
-cansend vcan0 2A0#DC05DC05D0070000
+cansend vcan0 2A1#E803D00700000000
 
 # Optional: hand it to the planner rather than the gamepad
 # (channel 5 = 2000). Needs a standstill, which the host always is.
-cansend vcan0 2A1#D007000000000000
+cansend vcan0 2A1#D007D00700000000
 ```
+
+Channels 7 and 8 read as 0 in these frames, which is outside every
+switch margin and therefore the safe fallback. The frames above are the
+Mini's layout; on OVCS1 the level is channel 3, in `0x2A0`.
 
 `ready_to_drive` is hardcoded `true` on Mini (`OvcsMini.Vms`), so
 nothing else is needed there. On a vehicle whose `ready_to_drive`

--- a/libraries/ovcs_can/priv/can/components/ovcs/0x700_controller_configuration.yml
+++ b/libraries/ovcs_can/priv/can/components/ovcs/0x700_controller_configuration.yml
@@ -105,8 +105,15 @@ signals:
   - name: analog_pin2
     value_start: 52
     <<: *other_pin_configuration
+  # Edge counter on A1, the same physical pin as analog_pin0. Enabling
+  # both is invalid: the controller gives the pulse counter the pin.
+  # Bit 53 is zero in every configuration adopted before this signal
+  # existed, so those controllers keep reading it as disabled.
+  - name: pulse_pin0
+    value_start: 53
+    <<: *other_pin_configuration
   - name: filler1
     kind: static
-    value_start: 53
-    value_length: 11
+    value_start: 54
+    value_length: 10
     value: 0x00

--- a/libraries/ovcs_can/priv/can/components/ovcs/generic_controller/0x7X9_pulse_counter_status_signals.yml
+++ b/libraries/ovcs_can/priv/can/components/ovcs/generic_controller/0x7X9_pulse_counter_status_signals.yml
@@ -1,0 +1,26 @@
+---
+# Emitted every 10 ms, only by a controller whose pulse_pin0 is enabled.
+#
+# The controller measures the period between rising edges with an
+# interrupt and reports the frequency, so the consumer gets a rate
+# rather than a sample: an analogRead() of a hall sensor every 10 ms
+# only ever shows which phase of the square wave the sample landed on.
+# The frequency decays to zero once no edge has arrived for a second,
+# which sets the lowest reportable rate at 1 Hz.
+#
+# The count wraps at 65535 and is there for odometry and diagnostics;
+# a receiver that wants distance integrates the difference between
+# consecutive frames.
+- name: pulse_pin0_count
+  kind: integer
+  value_start: 0
+  value_length: 16
+  endianness: little
+- name: pulse_pin0_frequency
+  kind: integer
+  unit: Hz
+  value_start: 16
+  value_length: 16
+  endianness: little
+  scale: "0.1"
+  precision: 1

--- a/libraries/ovcs_can/priv/can/components/ovcs/generic_controller/0x7X9_pulse_counter_status_signals.yml
+++ b/libraries/ovcs_can/priv/can/components/ovcs/generic_controller/0x7X9_pulse_counter_status_signals.yml
@@ -5,8 +5,8 @@
 # interrupt and reports the frequency, so the consumer gets a rate
 # rather than a sample: an analogRead() of a hall sensor every 10 ms
 # only ever shows which phase of the square wave the sample landed on.
-# The frequency decays to zero once no edge has arrived for a second,
-# which sets the lowest reportable rate at 1 Hz.
+# The frequency decays to zero once no edge has arrived for two seconds,
+# which sets the lowest reportable rate at 0.5 Hz.
 #
 # The count wraps at 65535 and is there for odometry and diagnostics;
 # a receiver that wants distance integrates the difference between
@@ -17,7 +17,7 @@
   value_length: 16
   endianness: little
 - name: pulse_pin0_frequency
-  kind: integer
+  kind: decimal
   unit: Hz
   value_start: 16
   value_length: 16

--- a/vehicles/ovcs1/lib/ovcs1/vms/composer/generic_controller.ex
+++ b/vehicles/ovcs1/lib/ovcs1/vms/composer/generic_controller.ex
@@ -30,7 +30,8 @@ defmodule Ovcs1.Vms.Composer.GenericController do
         "dac_pin0" => "disabled",
         "analog_pin0" => "disabled",
         "analog_pin1" => "disabled",
-        "analog_pin2" => "disabled"
+        "analog_pin2" => "disabled",
+        "pulse_pin0" => "disabled"
       },
       Vms.RearController => %{
         "controller_id" => 1,
@@ -59,7 +60,8 @@ defmodule Ovcs1.Vms.Composer.GenericController do
         "dac_pin0" => "disabled",
         "analog_pin0" => "disabled",
         "analog_pin1" => "disabled",
-        "analog_pin2" => "disabled"
+        "analog_pin2" => "disabled",
+        "pulse_pin0" => "disabled"
       },
       Vms.ControlsController => %{
         "controller_id" => 2,
@@ -88,7 +90,8 @@ defmodule Ovcs1.Vms.Composer.GenericController do
         "dac_pin0" => "disabled",
         "analog_pin0" => "enabled",
         "analog_pin1" => "enabled",
-        "analog_pin2" => "disabled"
+        "analog_pin2" => "disabled",
+        "pulse_pin0" => "disabled"
       }
     }
   end

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -28,6 +28,15 @@ defmodule OvcsMini.Vms.Composer do
   # 13 m/s, but nothing has measured this one under load.
   @max_speed_m_s 5.0
 
+  # The hall sensor's magnet turns with the motor side of the drivetrain,
+  # so wheel speed needs the ratio down to the wheel. ESTIMATE: one
+  # pulse per turn, and a stock Slash 4x4 drivetrain of roughly 10.5:1
+  # (2.72 transmission, 50/13 spur to pinion). Only the product of the
+  # two matters, and it is measured directly: roll the vehicle one wheel
+  # turn and count the pulses on `0x709`.
+  @pulses_per_revolution 1
+  @gear_ratio 10.5
+
   @impl VmsCore.Vehicle
   def children do
     [
@@ -132,21 +141,11 @@ defmodule OvcsMini.Vms.Composer do
          # bench", has the frames.
          default_control_level: :manual,
          ready_to_drive_source: Vms,
-         # KNOWN GAP. The manager only allows a change into `:radio`,
-         # into `:ros`, or into the `:autonomous` commander at a
-         # standstill, read from a `:speed` broadcast. Nothing on Mini
-         # publishes one. The motor's hall sensor is wired to the main
-         # controller's A0, but the controller reads it with a plain
-         # `analogRead()` every 10 ms, so `Traxxas.Motor` sees a
-         # sampled square wave rather than a rate: `:raw_rotation_per_minute`
-         # is an amplitude, and `:moving` is whichever phase the sample
-         # landed on.
-         #
-         # With no source the manager's speed stays at zero, so the
-         # interlock is *permissive*: mode changes are allowed at any
-         # speed. Closing it needs the controller to count pulses on
-         # that pin and put a rate on the bus.
-         speed_source: nil
+         # The standstill gate on every mode change reads this. It is
+         # exactly zero once the hall sensor has been quiet for a
+         # second, and the gear ratio above only scales what counts as
+         # moving, so an estimate there does not weaken the gate.
+         speed_source: Traxxas.Motor
        }},
       # The manager owns the choice now, so the drivetrain follows
       # whichever source it names rather than being wired to one
@@ -169,7 +168,10 @@ defmodule OvcsMini.Vms.Composer do
       {Traxxas.Motor,
        %{
          controller: Vms.MainController,
-         rotation_per_minute_pin: 0
+         pulse_pin: 0,
+         pulses_per_revolution: @pulses_per_revolution,
+         gear_ratio: @gear_ratio,
+         wheel_radius: OvcsMini.geometry().wheel_radius
        }},
       {VmsCore.Status,
        %{

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -181,7 +181,6 @@ defmodule OvcsMini.Vms.Composer do
       {Traxxas.Motor,
        %{
          controller: Vms.MainController,
-         pulse_pin: 0,
          pulses_per_revolution: @pulses_per_revolution,
          gear_ratio: @gear_ratio,
          wheel_radius: OvcsMini.geometry().wheel_radius

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -83,12 +83,13 @@ defmodule OvcsMini.Vms.Composer do
       # decides, which is the whole reason they route through it rather
       # than being read where the actuators are wired.
       #
-      # This is the Mini transmitter's layout over ExpressLRS: sticks on
-      # 1 and 2, switches from 5 up, 3 and 4 unused. Channel 5 is the
-      # link's 2-position arm channel and cannot carry a middle
-      # position, so the three-position level goes on 6 and the
-      # two-position commander takes 5. OVCS1 puts the level on 3 and
-      # direction on 4; docs/vehicle_parameterisation.md has both.
+      # This is the Mini transmitter's layout over ExpressLRS in MAVLink
+      # link mode, which forces the Hybrid switch mode: sticks on 1 and
+      # 2, switches from 5 up, 3 and 4 unused. Channel 5 is the link's
+      # 2-position arm channel and cannot carry a middle position, so
+      # the three-position level goes on 6 and the two-position
+      # commander takes 5. docs/vehicle_parameterisation.md has the
+      # layout of every vehicle.
       {OVCS.RadioControl.RequestedControlLevel,
        %{
          radio_control_channel: 6
@@ -97,10 +98,10 @@ defmodule OvcsMini.Vms.Composer do
        %{
          radio_control_channel: 5
        }},
-      # Wired and published, but no actuator on the Mini reads a
-      # direction: reverse is a negative throttle here. It is the radio
-      # direction source so the value shows up on the bus and the
-      # dashboard, and so a drivetrain that needs it can take it later.
+      # Started so the value is published; no actuator on the Mini
+      # reads a direction, since reverse is a negative throttle here.
+      # Named as the radio source below so a drivetrain that consumes
+      # direction can be wired without touching the manager.
       {OVCS.RadioControl.Direction,
        %{
          radio_control_channel: 7
@@ -147,9 +148,10 @@ defmodule OvcsMini.Vms.Composer do
          # `radio_control_bridge_config(:host)` declares no components,
          # so nothing emits 0x2A0/0x2A1, channel 6 stays at its default
          # 1000, and joystick input on 0x2B0/0x2B1 is discarded with no
-         # log. Synthesise the switches with `cansend` --
-         # docs/vehicle_parameterisation.md, "Driving on the host
-         # bench", has the frames.
+         # log. Nothing emits the pulse counter frame either, so the
+         # speed is unknown and the manager refuses every mode change
+         # until one is synthesised. docs/vehicle_parameterisation.md,
+         # "Driving on the host bench", has the frames for both.
          default_control_level: :manual,
          ready_to_drive_source: Vms,
          # The standstill gate on every mode change reads this. It is

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -77,22 +77,33 @@ defmodule OvcsMini.Vms.Composer do
        %{
          radio_control_channel: 2
        }},
-      # Two switches, two questions. Channel 3 says who has authority,
+      # Two switches, two questions. Channel 6 says who has authority,
       # channel 5 says which ROS node commands when ROS does — see
       # `Managers.ControlLevel`. Both only *request*; the manager
       # decides, which is the whole reason they route through it rather
       # than being read where the actuators are wired.
       #
-      # Channel 3 for authority, with 4 left free for direction, is the
-      # OVCS1 convention — so a transmitter set up for one vehicle
-      # reads the same way on the other.
+      # This is the Mini transmitter's layout over ExpressLRS: sticks on
+      # 1 and 2, switches from 5 up, 3 and 4 unused. Channel 5 is the
+      # link's 2-position arm channel and cannot carry a middle
+      # position, so the three-position level goes on 6 and the
+      # two-position commander takes 5. OVCS1 puts the level on 3 and
+      # direction on 4; docs/vehicle_parameterisation.md has both.
       {OVCS.RadioControl.RequestedControlLevel,
        %{
-         radio_control_channel: 3
+         radio_control_channel: 6
        }},
       {OVCS.RadioControl.RequestedRosCommander,
        %{
          radio_control_channel: 5
+       }},
+      # Wired and published, but no actuator on the Mini reads a
+      # direction: reverse is a negative throttle here. It is the radio
+      # direction source so the value shows up on the bus and the
+      # dashboard, and so a drivetrain that needs it can take it later.
+      {OVCS.RadioControl.Direction,
+       %{
+         radio_control_channel: 7
        }},
       {Managers.ControlLevel,
        %{
@@ -108,7 +119,7 @@ defmodule OvcsMini.Vms.Composer do
          # does, because its throttle axis is unsigned.
          requested_direction_sources: %{
            manual: nil,
-           radio: nil,
+           radio: OVCS.RadioControl.Direction,
            ros: %{teleop: OVCS.ROSControl.Direction, autonomous: nil}
          },
          requested_throttle_sources: %{
@@ -134,7 +145,7 @@ defmodule OvcsMini.Vms.Composer do
          #
          # On the host bench that means nothing commands it at all:
          # `radio_control_bridge_config(:host)` declares no components,
-         # so nothing emits 0x2A0/0x2A1, channel 3 stays at its default
+         # so nothing emits 0x2A0/0x2A1, channel 6 stays at its default
          # 1000, and joystick input on 0x2B0/0x2B1 is discarded with no
          # log. Synthesise the switches with `cansend` --
          # docs/vehicle_parameterisation.md, "Driving on the host

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -28,14 +28,14 @@ defmodule OvcsMini.Vms.Composer do
   # 13 m/s, but nothing has measured this one under load.
   @max_speed_m_s 5.0
 
-  # The hall sensor's magnet turns with the motor side of the drivetrain,
-  # so wheel speed needs the ratio down to the wheel. ESTIMATE: one
-  # pulse per turn, and a stock Slash 4x4 drivetrain of roughly 10.5:1
-  # (2.72 transmission, 50/13 spur to pinion). Only the product of the
-  # two matters, and it is measured directly: roll the vehicle one wheel
-  # turn and count the pulses on `0x709`.
+  # The trigger magnet sits in the spur gear, so wheel speed needs the
+  # ratio from the spur gear to the wheels: the Slash 4x4 transmission's
+  # fixed 2.72:1. The pinion does not enter into it. One magnet, one
+  # pulse per spur turn. ESTIMATE until measured: turn the spur gear by
+  # hand until a wheel completes one revolution and count the pulses on
+  # `0x709`; only the product of the two constants matters.
   @pulses_per_revolution 1
-  @gear_ratio 10.5
+  @gear_ratio 2.72
 
   @impl VmsCore.Vehicle
   def children do
@@ -142,8 +142,8 @@ defmodule OvcsMini.Vms.Composer do
          default_control_level: :manual,
          ready_to_drive_source: Vms,
          # The standstill gate on every mode change reads this. It is
-         # exactly zero once the hall sensor has been quiet for a
-         # second, and the gear ratio above only scales what counts as
+         # exactly zero once the hall sensor has been quiet for two
+         # seconds, and the gear ratio above only scales what counts as
          # moving, so an estimate there does not weaken the gate.
          speed_source: Traxxas.Motor
        }},

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/dashboard_page.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/dashboard_page.ex
@@ -1,5 +1,7 @@
 defmodule OvcsMini.Vms.Composer.Dashboard.DashboardPage do
   alias OvcsMini.Vms
+  alias VmsCore.Components.Traxxas
+  alias VmsCore.Managers
   alias VmsCore.Status
 
   def definition(order: order) do
@@ -27,6 +29,55 @@ defmodule OvcsMini.Vms.Composer.Dashboard.DashboardPage do
               name: "Main Controller Alive",
               module: Vms.MainController,
               key: :is_alive
+            }
+          ]
+        },
+        "drivetrain" => %{
+          order: 1,
+          name: "Drivetrain",
+          type: "table",
+          rows: [
+            %{
+              type: :metric,
+              name: "Selected Control Level",
+              module: Managers.ControlLevel,
+              key: :selected_control_level
+            },
+            %{
+              type: :metric,
+              name: "Selected ROS Commander",
+              module: Managers.ControlLevel,
+              key: :selected_ros_commander
+            },
+            %{type: :metric, name: "Speed", module: Traxxas.Motor, key: :speed, unit: "km/h"},
+            %{
+              type: :metric,
+              name: "Motor RPM",
+              module: Traxxas.Motor,
+              key: :rotation_per_minute
+            }
+          ]
+        },
+        "speed-and-rpm" => %{
+          order: 2,
+          name: "Speed & RPM",
+          type: "lineChart",
+          serie_max_size: 300,
+          y_axis: [
+            %{
+              min: 0,
+              max: 30,
+              label: "km/h",
+              series: [%{name: "Speed", metric: %{module: Traxxas.Motor, key: :speed}}]
+            },
+            %{
+              position: "right",
+              min: 0,
+              max: 10_000,
+              label: "RPM",
+              series: [
+                %{name: "Motor RPM", metric: %{module: Traxxas.Motor, key: :rotation_per_minute}}
+              ]
             }
           ]
         }

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/generic_controllers_page.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/generic_controllers_page.ex
@@ -1,6 +1,7 @@
 defmodule OvcsMini.Vms.Composer.Dashboard.GenericControllersPage do
   alias OvcsMini.Vms
   alias VmsCore.Components.OVCS.GenericController
+  alias VmsCore.Components.Traxxas
 
   def definition(order: order) do
     %{
@@ -65,9 +66,23 @@ defmodule OvcsMini.Vms.Composer.Dashboard.GenericControllersPage do
             },
             %{
               type: :metric,
-              name: "Motor RPM",
+              name: "Hall sensor frequency",
               module: Vms.MainController,
-              key: :received_analog_pin0_value
+              key: :received_pulse_pin0_frequency,
+              unit: "Hz"
+            },
+            %{
+              type: :metric,
+              name: "Motor RPM",
+              module: Traxxas.Motor,
+              key: :rotation_per_minute
+            },
+            %{
+              type: :metric,
+              name: "Speed",
+              module: Traxxas.Motor,
+              key: :speed,
+              unit: "km/h"
             }
           ]
         }

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/generic_controllers_page.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/generic_controllers_page.ex
@@ -1,7 +1,6 @@
 defmodule OvcsMini.Vms.Composer.Dashboard.GenericControllersPage do
   alias OvcsMini.Vms
   alias VmsCore.Components.OVCS.GenericController
-  alias VmsCore.Components.Traxxas
 
   def definition(order: order) do
     %{
@@ -66,23 +65,16 @@ defmodule OvcsMini.Vms.Composer.Dashboard.GenericControllersPage do
             },
             %{
               type: :metric,
-              name: "Hall sensor frequency",
+              name: "Pulse counter frequency",
               module: Vms.MainController,
               key: :received_pulse_pin0_frequency,
               unit: "Hz"
             },
             %{
               type: :metric,
-              name: "Motor RPM",
-              module: Traxxas.Motor,
-              key: :rotation_per_minute
-            },
-            %{
-              type: :metric,
-              name: "Speed",
-              module: Traxxas.Motor,
-              key: :speed,
-              unit: "km/h"
+              name: "Pulse counter count",
+              module: Vms.MainController,
+              key: :received_pulse_pin0_count
             }
           ]
         }

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/radio_control_page.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/radio_control_page.ex
@@ -21,9 +21,15 @@ defmodule OvcsMini.Vms.Composer.Dashboard.RadioControlPage do
             },
             %{
               type: :metric,
-              name: "Requested Gear",
-              module: RadioControl.Gear,
-              key: :requested_gear
+              name: "Requested ROS Commander",
+              module: RadioControl.RequestedRosCommander,
+              key: :requested_ros_commander
+            },
+            %{
+              type: :metric,
+              name: "Requested Direction",
+              module: RadioControl.Direction,
+              key: :requested_direction
             },
             %{
               type: :metric,

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/generic_controller.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/generic_controller.ex
@@ -28,9 +28,12 @@ defmodule OvcsMini.Vms.Composer.GenericController do
         "pwm_pin1" => "disabled",
         "pwm_pin2" => "disabled",
         "dac_pin0" => "disabled",
-        "analog_pin0" => "enabled",
+        "analog_pin0" => "disabled",
         "analog_pin1" => "disabled",
-        "analog_pin2" => "disabled"
+        "analog_pin2" => "disabled",
+        # The motor's hall sensor, on A1. Counted by interrupt on the
+        # controller and reported as a frequency; see `Traxxas.Motor`.
+        "pulse_pin0" => "enabled"
       }
     }
   end

--- a/vehicles/ovcs_mini/priv/can/generic_controller/0x709_main_controller_pulse_counter_status.yml
+++ b/vehicles/ovcs_mini/priv/can/generic_controller/0x709_main_controller_pulse_counter_status.yml
@@ -1,0 +1,5 @@
+---
+name: main_controller_pulse_counter_status
+id: 0x709
+frequency: 10
+signals: import!:@ovcs_can:can/components/ovcs/generic_controller/0x7X9_pulse_counter_status_signals.yml

--- a/vehicles/ovcs_mini/priv/can/vms.yml
+++ b/vehicles/ovcs_mini/priv/can/vms.yml
@@ -12,6 +12,7 @@ can_networks:
     received_frames:
       - import!:generic_controller/0x701_main_controller_alive.yml
       - import!:generic_controller/0x704_main_controller_digital_and_analog_pin_status.yml
+      - import!:generic_controller/0x709_main_controller_pulse_counter_status.yml
       - import!:@ovcs_can:can/components/ovcs/0x2A0_radio_control_channels0.yml
       - import!:@ovcs_can:can/components/ovcs/0x2A1_radio_control_channels1.yml
       - import!:@ovcs_can:can/components/ovcs/0x2B0_ros_control0.yml

--- a/vms/core/lib/vms_core/components/ovcs/generic_controller.ex
+++ b/vms/core/lib/vms_core/components/ovcs/generic_controller.ex
@@ -49,6 +49,13 @@ defmodule VmsCore.Components.OVCS.GenericController do
     "analog_pin2_value" => 0
   }
 
+  # Reported on a frame of their own, and only by a controller whose
+  # pulse pin is enabled: the other controllers declare no such frame.
+  @pulse_pins %{
+    "pulse_pin0_count" => 0,
+    "pulse_pin0_frequency" => 0
+  }
+
   @external_pwm_pins %{
     "external_pwm0_enabled" => false,
     "external_pwm0_duty_cycle" => 0,
@@ -80,6 +87,7 @@ defmodule VmsCore.Components.OVCS.GenericController do
     digital_and_analog_pin_status_frame_name =
       compute_frame_name(process_name, "digital_and_analog_pin_status")
 
+    pulse_counter_status_frame_name = compute_frame_name(process_name, "pulse_counter_status")
     digital_pin_request_frame_name = compute_frame_name(process_name, "digital_pin_request")
     other_pin_request_frame_name = compute_frame_name(process_name, "other_pin_request")
 
@@ -90,11 +98,18 @@ defmodule VmsCore.Components.OVCS.GenericController do
       compute_frame_name(process_name, "external_pwm3_request")
     ]
 
+    controller_configuration = Application.vehicle_composer().generic_controllers()[process_name]
+    pulse_pin_enabled = controller_configuration["pulse_pin0"] == "enabled"
+
     :ok =
       Receiver.subscribe(self(), :ovcs, [
         alive_frame_name,
         digital_and_analog_pin_status_frame_name
       ])
+
+    if pulse_pin_enabled do
+      :ok = Receiver.subscribe(self(), :ovcs, pulse_counter_status_frame_name)
+    end
 
     :ok = ReceivedFrameWatcher.enable(:ovcs, alive_frame_name)
 
@@ -131,13 +146,14 @@ defmodule VmsCore.Components.OVCS.GenericController do
     end)
 
     enabled_pin_names =
-      Application.vehicle_composer().generic_controllers()[process_name]
+      controller_configuration
       |> Enum.flat_map(fn {key, value} ->
         case value != "disabled" do
           true ->
             case key do
               "digital_pin" <> _ -> [key <> "_enabled"]
               "analog_pin" <> _ -> [key <> "_value"]
+              "pulse_pin" <> _ -> [key <> "_count", key <> "_frequency"]
               "pwm_pin" <> _ -> [key <> "_duty_cycle"]
               "dac_pin" <> _ -> [key <> "_duty_cycle"]
               _ -> []
@@ -177,6 +193,7 @@ defmodule VmsCore.Components.OVCS.GenericController do
         case name do
           "digital" <> _ -> true
           "analog" <> _ -> true
+          "pulse" <> _ -> true
           _ -> false
         end
       end)
@@ -189,10 +206,11 @@ defmodule VmsCore.Components.OVCS.GenericController do
        process_name: process_name,
        alive_frame_name: alive_frame_name,
        digital_and_analog_pin_status_frame_name: digital_and_analog_pin_status_frame_name,
+       pulse_counter_status_frame_name: pulse_counter_status_frame_name,
        digital_pin_request_frame_name: digital_pin_request_frame_name,
        other_pin_request_frame_name: other_pin_request_frame_name,
        external_pwm_request_frame_names: external_pwm_request_frame_names,
-       received_pins: @digital_pins |> Map.merge(@analog_pins),
+       received_pins: @digital_pins |> Map.merge(@analog_pins) |> Map.merge(@pulse_pins),
        requested_pins:
          @digital_pins
          |> Map.merge(@pwm_pins)
@@ -218,12 +236,16 @@ defmodule VmsCore.Components.OVCS.GenericController do
     {:noreply, state}
   end
 
+  # Two frames feed `received_pins`, so each merges its own signals
+  # rather than replacing the map, or the other frame's values would be
+  # wiped 10 ms later.
   @impl true
   def handle_info({:handle_frame, %Frame{name: name, signals: signals}}, state)
-      when name == state.digital_and_analog_pin_status_frame_name do
+      when name == state.digital_and_analog_pin_status_frame_name or
+             name == state.pulse_counter_status_frame_name do
     received_pins =
       signals
-      |> Enum.reduce(%{}, fn {_, signal}, pins ->
+      |> Enum.reduce(state.received_pins, fn {_, signal}, pins ->
         Map.put(pins, signal.name, signal.value)
       end)
 

--- a/vms/core/lib/vms_core/components/ovcs/generic_controller.ex
+++ b/vms/core/lib/vms_core/components/ovcs/generic_controller.ex
@@ -107,8 +107,13 @@ defmodule VmsCore.Components.OVCS.GenericController do
         digital_and_analog_pin_status_frame_name
       ])
 
+    # Watched as well as subscribed: a controller on old firmware, or
+    # not yet re-adopted, never emits this frame, and a stale or
+    # default frequency would read as a standstill. While the frame is
+    # dead the pulse signals are broadcast as nil.
     if pulse_pin_enabled do
       :ok = Receiver.subscribe(self(), :ovcs, pulse_counter_status_frame_name)
+      :ok = ReceivedFrameWatcher.enable(:ovcs, pulse_counter_status_frame_name)
     end
 
     :ok = ReceivedFrameWatcher.enable(:ovcs, alive_frame_name)
@@ -221,6 +226,7 @@ defmodule VmsCore.Components.OVCS.GenericController do
        control_other_pins: control_other_pins,
        requested_pin_names: requested_pin_names,
        received_pin_names: received_pin_names,
+       pulse_pin_enabled: pulse_pin_enabled,
        status: nil,
        expansion_board1_last_error: nil,
        expansion_board2_last_error: nil
@@ -393,15 +399,28 @@ defmodule VmsCore.Components.OVCS.GenericController do
     Emitter.disable(:ovcs, "controller_configuration")
   end
 
+  defp pulse_frame_alive?(%{pulse_pin_enabled: false}), do: false
+
+  defp pulse_frame_alive?(state) do
+    {:ok, alive} = ReceivedFrameWatcher.is_alive?(:ovcs, state.pulse_counter_status_frame_name)
+    alive
+  end
+
   defp compute_frame_name(process_name, suffix) do
     controller_name = Macro.underscore(process_name) |> String.split("/") |> List.last()
     "#{controller_name}_#{suffix}"
   end
 
   defp emit_metrics(state) do
+    pulse_frame_alive = pulse_frame_alive?(state)
+
     state.received_pin_names
     |> Enum.each(fn name ->
-      value = state.received_pins[name]
+      value =
+        case name do
+          "pulse" <> _ when not pulse_frame_alive -> nil
+          _ -> state.received_pins[name]
+        end
 
       Bus.broadcast("messages", %Bus.Message{
         name: "received_#{name}" |> String.to_atom(),

--- a/vms/core/lib/vms_core/components/ovcs/generic_controller.ex
+++ b/vms/core/lib/vms_core/components/ovcs/generic_controller.ex
@@ -101,6 +101,14 @@ defmodule VmsCore.Components.OVCS.GenericController do
     controller_configuration = Application.vehicle_composer().generic_controllers()[process_name]
     pulse_pin_enabled = controller_configuration["pulse_pin0"] == "enabled"
 
+    # Both live on A1. The firmware gives the pin to the pulse counter
+    # and reports the analog input as a permanent zero, which would
+    # look like a real reading; refuse the combination here instead.
+    if pulse_pin_enabled and controller_configuration["analog_pin0"] == "enabled" do
+      raise ArgumentError,
+            "#{inspect(process_name)} enables both pulse_pin0 and analog_pin0, which share A1"
+    end
+
     :ok =
       Receiver.subscribe(self(), :ovcs, [
         alive_frame_name,

--- a/vms/core/lib/vms_core/components/traxxas/motor.ex
+++ b/vms/core/lib/vms_core/components/traxxas/motor.ex
@@ -1,32 +1,73 @@
 defmodule VmsCore.Components.Traxxas.Motor do
   @moduledoc """
-    Traxxas' motor feedback
+  Motor speed from a hall effect sensor.
+
+  The sensor's pulse train is counted by the generic controller, which
+  reports a frequency on its pulse counter frame. This turns that
+  frequency into the speed of the sensed shaft and of the vehicle:
+
+      shaft rpm   = frequency · 60 / pulses_per_revolution
+      wheel rev/s = frequency / pulses_per_revolution / gear_ratio
+      speed       = wheel rev/s · 2π · wheel_radius
+
+  `:speed` is published in km/h, the unit every other `:speed` on the
+  bus uses. `:moving` is derived from it.
+
+  ## Standstill
+
+  The controller reports a frequency of zero once no edge has arrived
+  for a second, so `:speed` reads exactly zero at rest and
+  `Managers.ControlLevel`'s standstill gate holds. The same second sets
+  the slowest speed that reads as motion at all.
+
+  ## Options
+
+    * `:controller` — the generic controller the sensor is wired to.
+    * `:pulse_pin` — its pulse pin index (`0`).
+    * `:pulses_per_revolution` — edges per turn of the shaft the magnet
+      is on.
+    * `:gear_ratio` — turns of that shaft per turn of the wheel.
+    * `:wheel_radius` — metres, from the vehicle's `geometry/0`.
+
+  The product `pulses_per_revolution · gear_ratio` is the only thing
+  that matters, and it is measured by rolling the vehicle one wheel
+  turn and counting pulses.
   """
   use GenServer
+  alias Decimal, as: D
   alias OvcsBus, as: Bus
 
   @loop_period 10
+  @zero D.new(0)
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
   @impl true
-  def init(%{
-        controller: controller,
-        rotation_per_minute_pin: rotation_per_minute_pin
-      }) do
+  def init(
+        %{
+          controller: controller,
+          pulses_per_revolution: pulses_per_revolution,
+          gear_ratio: gear_ratio,
+          wheel_radius: wheel_radius
+        } = args
+      ) do
     Bus.subscribe("messages")
     {:ok, timer} = :timer.send_interval(@loop_period, :loop)
+    pulse_pin = Map.get(args, :pulse_pin, 0)
 
     {:ok,
      %{
        loop_timer: timer,
        controller: controller,
-       rotation_per_minute_pin: rotation_per_minute_pin,
-       # TODO dynamic name
-       rotation_per_minute_pin_name: :received_analog_pin0_value,
-       raw_rotation_per_minute: 0,
+       frequency_name: :"received_pulse_pin#{pulse_pin}_frequency",
+       pulses_per_revolution: pulses_per_revolution,
+       gear_ratio: gear_ratio,
+       wheel_radius: wheel_radius,
+       frequency: @zero,
+       rotation_per_minute: @zero,
+       speed: @zero,
        moving: false
      }}
   end
@@ -41,9 +82,9 @@ defmodule VmsCore.Components.Traxxas.Motor do
     {:noreply, state}
   end
 
-  def handle_info(%Bus.Message{name: name, value: raw_rotation_per_minute, source: source}, state)
-      when source == state.controller and name == state.rotation_per_minute_pin_name do
-    {:noreply, %{state | raw_rotation_per_minute: raw_rotation_per_minute}}
+  def handle_info(%Bus.Message{name: name, value: frequency, source: source}, state)
+      when source == state.controller and name == state.frequency_name do
+    {:noreply, %{state | frequency: D.new(frequency)}}
   end
 
   def handle_info(%Bus.Message{}, state) do
@@ -51,21 +92,43 @@ defmodule VmsCore.Components.Traxxas.Motor do
   end
 
   defp compute_values(state) do
-    moving =
-      case state.raw_rotation_per_minute do
-        0 -> false
-        _ -> true
-      end
+    speed = speed_km_h(state.frequency, state)
 
-    %{state | moving: moving}
+    %{
+      state
+      | rotation_per_minute: rotation_per_minute(state.frequency, state.pulses_per_revolution),
+        speed: speed,
+        moving: D.gt?(speed, @zero)
+    }
+  end
+
+  @doc false
+  def rotation_per_minute(frequency, pulses_per_revolution) do
+    frequency |> D.mult(60) |> D.div(D.from_float(pulses_per_revolution / 1))
+  end
+
+  @doc false
+  def speed_km_h(frequency, %{
+        pulses_per_revolution: pulses_per_revolution,
+        gear_ratio: gear_ratio,
+        wheel_radius: wheel_radius
+      }) do
+    wheel_circumference = 2 * :math.pi() * wheel_radius
+    metres_per_pulse = wheel_circumference / (pulses_per_revolution * gear_ratio)
+
+    frequency
+    |> D.mult(D.from_float(metres_per_pulse * 3.6))
+    |> D.round(2)
   end
 
   defp emit_metrics(state) do
     Bus.broadcast("messages", %Bus.Message{
-      name: :raw_rotation_per_minute,
-      value: state.raw_rotation_per_minute,
+      name: :rotation_per_minute,
+      value: state.rotation_per_minute,
       source: __MODULE__
     })
+
+    Bus.broadcast("messages", %Bus.Message{name: :speed, value: state.speed, source: __MODULE__})
 
     Bus.broadcast("messages", %Bus.Message{name: :moving, value: state.moving, source: __MODULE__})
 

--- a/vms/core/lib/vms_core/components/traxxas/motor.ex
+++ b/vms/core/lib/vms_core/components/traxxas/motor.ex
@@ -28,8 +28,8 @@ defmodule VmsCore.Components.Traxxas.Motor do
 
   ## Options
 
-    * `:controller` — the generic controller the sensor is wired to.
-    * `:pulse_pin` — its pulse pin index (`0`).
+    * `:controller` — the generic controller the sensor is wired to, on
+      its pulse pin 0, the only one a controller has.
     * `:pulses_per_revolution` — edges per turn of the shaft the magnet
       is on.
     * `:gear_ratio` — turns of that shaft per turn of the wheel.
@@ -44,72 +44,67 @@ defmodule VmsCore.Components.Traxxas.Motor do
   alias OvcsBus, as: Bus
 
   @loop_period 10
-  @zero D.new(0)
+  @frequency_name :received_pulse_pin0_frequency
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
 
   @impl true
-  def init(
-        %{
-          controller: controller,
-          pulses_per_revolution: pulses_per_revolution,
-          gear_ratio: gear_ratio,
-          wheel_radius: wheel_radius
-        } = args
-      ) do
+  def init(%{
+        controller: controller,
+        pulses_per_revolution: pulses_per_revolution,
+        gear_ratio: gear_ratio,
+        wheel_radius: wheel_radius
+      }) do
     Bus.subscribe("messages")
     {:ok, timer} = :timer.send_interval(@loop_period, :loop)
-    pulse_pin = Map.get(args, :pulse_pin, 0)
 
+    # Unknown until the controller says otherwise. Zero here would let
+    # the standstill gate pass before the first frequency arrives, or
+    # for ever if the controller named here never publishes one.
     {:ok,
      %{
        loop_timer: timer,
        controller: controller,
-       frequency_name: :"received_pulse_pin#{pulse_pin}_frequency",
        pulses_per_revolution: pulses_per_revolution,
        speed_factor: speed_factor(pulses_per_revolution, gear_ratio, wheel_radius),
-       frequency: @zero,
-       rotation_per_minute: @zero,
-       speed: @zero
+       rotation_per_minute: nil,
+       speed: nil
      }}
   end
 
   @impl true
   def handle_info(:loop, state) do
-    state =
-      state
-      |> compute_values()
-      |> emit_metrics()
-
-    {:noreply, state}
+    {:noreply, emit_metrics(state)}
   end
 
-  def handle_info(%Bus.Message{name: name, value: frequency, source: source}, state)
-      when source == state.controller and name == state.frequency_name do
-    {:noreply, %{state | frequency: frequency && D.new(frequency)}}
+  # Computed when the frequency arrives, not on every tick: the
+  # constants are fixed and the frequency only changes with a message.
+  def handle_info(%Bus.Message{name: @frequency_name, value: nil, source: source}, state)
+      when source == state.controller do
+    {:noreply, %{state | rotation_per_minute: nil, speed: nil}}
+  end
+
+  def handle_info(%Bus.Message{name: @frequency_name, value: frequency, source: source}, state)
+      when source == state.controller do
+    {:noreply,
+     %{
+       state
+       | rotation_per_minute: rotation_per_minute(frequency, state.pulses_per_revolution),
+         speed: speed_km_h(frequency, state.speed_factor)
+     }}
   end
 
   def handle_info(%Bus.Message{}, state) do
     {:noreply, state}
   end
 
-  defp compute_values(%{frequency: nil} = state) do
-    %{state | rotation_per_minute: nil, speed: nil}
-  end
-
-  defp compute_values(state) do
-    %{
-      state
-      | rotation_per_minute: rotation_per_minute(state.frequency, state.pulses_per_revolution),
-        speed: speed_km_h(state.frequency, state.speed_factor)
-    }
-  end
-
+  # The frequency arrives with one decimal (`0x7X9` decodes at
+  # precision 1), so the result carries one too: `6000.0`, not `6000`.
   @doc false
   def rotation_per_minute(frequency, pulses_per_revolution) do
-    frequency |> D.mult(60) |> D.div(pulses_per_revolution)
+    frequency |> D.new() |> D.mult(60) |> D.div(pulses_per_revolution)
   end
 
   # km/h per hertz, fixed at init: one wheel circumference per
@@ -122,7 +117,7 @@ defmodule VmsCore.Components.Traxxas.Motor do
 
   @doc false
   def speed_km_h(frequency, speed_factor) do
-    frequency |> D.mult(speed_factor) |> D.round(2)
+    frequency |> D.new() |> D.mult(speed_factor) |> D.round(2)
   end
 
   defp emit_metrics(state) do

--- a/vms/core/lib/vms_core/components/traxxas/motor.ex
+++ b/vms/core/lib/vms_core/components/traxxas/motor.ex
@@ -11,14 +11,20 @@ defmodule VmsCore.Components.Traxxas.Motor do
       speed       = wheel rev/s · 2π · wheel_radius
 
   `:speed` is published in km/h, the unit every other `:speed` on the
-  bus uses. `:moving` is derived from it.
+  bus uses.
 
-  ## Standstill
+  ## Standstill, and not knowing
 
   The controller reports a frequency of zero once no edge has arrived
-  for a second, so `:speed` reads exactly zero at rest and
-  `Managers.ControlLevel`'s standstill gate holds. The same second sets
-  the slowest speed that reads as motion at all.
+  for two seconds, so `:speed` reads exactly zero at rest and
+  `Managers.ControlLevel`'s standstill gate holds. The same two seconds
+  set the slowest speed that reads as motion at all, about 0.2 km/h on
+  the Mini.
+
+  When the controller's pulse frame is not arriving, the generic
+  controller publishes a nil frequency and this publishes a nil speed.
+  Nil is not zero: the manager refuses mode changes it cannot prove
+  safe rather than treating silence as a standstill.
 
   ## Options
 
@@ -63,12 +69,10 @@ defmodule VmsCore.Components.Traxxas.Motor do
        controller: controller,
        frequency_name: :"received_pulse_pin#{pulse_pin}_frequency",
        pulses_per_revolution: pulses_per_revolution,
-       gear_ratio: gear_ratio,
-       wheel_radius: wheel_radius,
+       speed_factor: speed_factor(pulses_per_revolution, gear_ratio, wheel_radius),
        frequency: @zero,
        rotation_per_minute: @zero,
-       speed: @zero,
-       moving: false
+       speed: @zero
      }}
   end
 
@@ -84,41 +88,41 @@ defmodule VmsCore.Components.Traxxas.Motor do
 
   def handle_info(%Bus.Message{name: name, value: frequency, source: source}, state)
       when source == state.controller and name == state.frequency_name do
-    {:noreply, %{state | frequency: D.new(frequency)}}
+    {:noreply, %{state | frequency: frequency && D.new(frequency)}}
   end
 
   def handle_info(%Bus.Message{}, state) do
     {:noreply, state}
   end
 
-  defp compute_values(state) do
-    speed = speed_km_h(state.frequency, state)
+  defp compute_values(%{frequency: nil} = state) do
+    %{state | rotation_per_minute: nil, speed: nil}
+  end
 
+  defp compute_values(state) do
     %{
       state
       | rotation_per_minute: rotation_per_minute(state.frequency, state.pulses_per_revolution),
-        speed: speed,
-        moving: D.gt?(speed, @zero)
+        speed: speed_km_h(state.frequency, state.speed_factor)
     }
   end
 
   @doc false
   def rotation_per_minute(frequency, pulses_per_revolution) do
-    frequency |> D.mult(60) |> D.div(D.from_float(pulses_per_revolution / 1))
+    frequency |> D.mult(60) |> D.div(pulses_per_revolution)
+  end
+
+  # km/h per hertz, fixed at init: one wheel circumference per
+  # `pulses_per_revolution · gear_ratio` pulses.
+  @doc false
+  def speed_factor(pulses_per_revolution, gear_ratio, wheel_radius) do
+    wheel_circumference = 2 * :math.pi() * wheel_radius
+    D.from_float(wheel_circumference * 3.6 / (pulses_per_revolution * gear_ratio))
   end
 
   @doc false
-  def speed_km_h(frequency, %{
-        pulses_per_revolution: pulses_per_revolution,
-        gear_ratio: gear_ratio,
-        wheel_radius: wheel_radius
-      }) do
-    wheel_circumference = 2 * :math.pi() * wheel_radius
-    metres_per_pulse = wheel_circumference / (pulses_per_revolution * gear_ratio)
-
-    frequency
-    |> D.mult(D.from_float(metres_per_pulse * 3.6))
-    |> D.round(2)
+  def speed_km_h(frequency, speed_factor) do
+    frequency |> D.mult(speed_factor) |> D.round(2)
   end
 
   defp emit_metrics(state) do
@@ -129,8 +133,6 @@ defmodule VmsCore.Components.Traxxas.Motor do
     })
 
     Bus.broadcast("messages", %Bus.Message{name: :speed, value: state.speed, source: __MODULE__})
-
-    Bus.broadcast("messages", %Bus.Message{name: :moving, value: state.moving, source: __MODULE__})
 
     state
   end

--- a/vms/core/lib/vms_core/managers/control_level.ex
+++ b/vms/core/lib/vms_core/managers/control_level.ex
@@ -208,11 +208,11 @@ defmodule VmsCore.Managers.ControlLevel do
         %{state | selected_control_level: :manual}
 
       requested_control_level == :radio && selected_control_level != :radio &&
-        is_nil(forced_control_level) && ready_to_drive && speed |> D.eq?(@zero) ->
+        is_nil(forced_control_level) && ready_to_drive && standstill?(speed) ->
         %{state | selected_control_level: :radio}
 
       requested_control_level == :ros && selected_control_level == :radio &&
-        is_nil(forced_control_level) && speed |> D.eq?(@zero) ->
+        is_nil(forced_control_level) && standstill?(speed) ->
         %{state | selected_control_level: :ros}
 
       requested_control_level == selected_control_level &&
@@ -266,6 +266,9 @@ defmodule VmsCore.Managers.ControlLevel do
       not state.ready_to_drive ->
         :not_ready_to_drive
 
+      is_nil(state.speed) ->
+        :speed_unknown
+
       not D.eq?(state.speed, @zero) ->
         {:moving, state.speed}
 
@@ -294,7 +297,7 @@ defmodule VmsCore.Managers.ControlLevel do
       state.selected_control_level != :ros ->
         %{state | selected_ros_commander: :teleop}
 
-      state.selected_ros_commander == :teleop && D.eq?(state.speed, @zero) ->
+      state.selected_ros_commander == :teleop && standstill?(state.speed) ->
         %{state | selected_ros_commander: :autonomous}
 
       true ->
@@ -318,6 +321,13 @@ defmodule VmsCore.Managers.ControlLevel do
   end
 
   defp select_sources(state), do: state
+
+  # A speed source that has gone quiet publishes nil, and unknown is not
+  # standstill: a vehicle that cannot prove it is stopped does not get a
+  # mode change. A vehicle with no speed source at all keeps the initial
+  # zero, which is the documented permissive case.
+  defp standstill?(nil), do: false
+  defp standstill?(speed), do: D.eq?(speed, @zero)
 
   # Only `:ros` is keyed by commander. Every other level names a single
   # source, so the second switch cannot affect it.

--- a/vms/core/lib/vms_core/managers/gear.ex
+++ b/vms/core/lib/vms_core/managers/gear.ex
@@ -159,7 +159,8 @@ defmodule VmsCore.Managers.Gear do
       requested_throttle: requested_throttle
     } = state
 
-    speed_near_zero = D.abs(speed) |> D.lt?(@gear_shift_speed_limit)
+    # A nil speed is a source that has gone quiet; unknown is not near zero.
+    speed_near_zero = not is_nil(speed) and D.abs(speed) |> D.lt?(@gear_shift_speed_limit)
     throttle_near_zero = D.lt?(requested_throttle, @gear_shift_throttle_limit)
 
     cond do

--- a/vms/core/test/components/traxxas/motor_test.exs
+++ b/vms/core/test/components/traxxas/motor_test.exs
@@ -1,0 +1,35 @@
+defmodule VmsCore.Components.Traxxas.MotorTest do
+  @moduledoc """
+  Pulse frequency to speed. The constants are the Mini's: a 0.0548 m
+  wheel, one pulse per turn of a shaft geared 10.5:1 to the wheel.
+  """
+  use ExUnit.Case, async: true
+
+  alias Decimal, as: D
+  alias VmsCore.Components.Traxxas.Motor
+
+  @options %{pulses_per_revolution: 1, gear_ratio: 10.5, wheel_radius: 0.0548}
+
+  test "no pulses is exactly zero, which is what the standstill gate needs" do
+    assert D.eq?(Motor.speed_km_h(D.new(0), @options), D.new(0))
+    assert D.eq?(Motor.rotation_per_minute(D.new(0), 1), D.new(0))
+  end
+
+  test "one wheel turn per second" do
+    # 10.5 pulses per second is one wheel revolution per second:
+    # 2π · 0.0548 m = 0.3443 m/s = 1.24 km/h.
+    speed = Motor.speed_km_h(D.new("10.5"), @options)
+    assert D.eq?(speed, D.new("1.24"))
+  end
+
+  test "shaft rpm follows pulses per revolution" do
+    assert D.eq?(Motor.rotation_per_minute(D.new("100"), 1), D.new("6000"))
+    assert D.eq?(Motor.rotation_per_minute(D.new("100"), 4), D.new("1500"))
+  end
+
+  test "more pulses per wheel turn means a slower vehicle for the same frequency" do
+    fast = Motor.speed_km_h(D.new("100"), @options) |> D.to_float()
+    slow = Motor.speed_km_h(D.new("100"), %{@options | pulses_per_revolution: 2}) |> D.to_float()
+    assert_in_delta slow, fast / 2, 0.01
+  end
+end

--- a/vms/core/test/components/traxxas/motor_test.exs
+++ b/vms/core/test/components/traxxas/motor_test.exs
@@ -21,11 +21,39 @@ defmodule VmsCore.Components.Traxxas.MotorTest do
     assert D.eq?(Motor.speed_km_h(D.new("2.72"), @factor), D.new("1.24"))
   end
 
-  test "shaft rpm follows pulses per revolution, as a plain integer" do
-    # `D.div/2` with an integer divisor keeps the exponent at zero, so
-    # the dashboard shows 6000 rather than 6.00E+3.
-    assert D.to_string(Motor.rotation_per_minute(D.new("100"), 1)) == "6000"
-    assert D.to_string(Motor.rotation_per_minute(D.new("100"), 4)) == "1500"
+  test "shaft rpm follows pulses per revolution and renders plainly" do
+    # The bus delivers the frequency with one decimal, as `0x7X9`
+    # decodes it. An integer divisor keeps that shape, so the dashboard
+    # shows 6000.0 rather than 6.00E+3.
+    assert D.to_string(Motor.rotation_per_minute(D.new("100.0"), 1)) == "6000.0"
+    assert D.to_string(Motor.rotation_per_minute(D.new("100.0"), 4)) == "1500.0"
+  end
+
+  test "before the first frequency, speed and rpm are unknown, not zero" do
+    {:ok, state} =
+      Motor.init(%{
+        controller: Ctrl,
+        pulses_per_revolution: 1,
+        gear_ratio: 2.72,
+        wheel_radius: 0.0548
+      })
+
+    {:ok, :cancel} = :timer.cancel(state.loop_timer)
+    assert state.speed == nil
+    assert state.rotation_per_minute == nil
+
+    message = %OvcsBus.Message{
+      name: :received_pulse_pin0_frequency,
+      value: D.new("2.72"),
+      source: Ctrl
+    }
+
+    {:noreply, state} = Motor.handle_info(message, state)
+    assert D.eq?(state.speed, D.new("1.24"))
+
+    dead = %OvcsBus.Message{name: :received_pulse_pin0_frequency, value: nil, source: Ctrl}
+    {:noreply, state} = Motor.handle_info(dead, state)
+    assert state.speed == nil
   end
 
   test "more pulses per wheel turn means a slower vehicle for the same frequency" do

--- a/vms/core/test/components/traxxas/motor_test.exs
+++ b/vms/core/test/components/traxxas/motor_test.exs
@@ -1,35 +1,36 @@
 defmodule VmsCore.Components.Traxxas.MotorTest do
   @moduledoc """
   Pulse frequency to speed. The constants are the Mini's: a 0.0548 m
-  wheel, one pulse per turn of a shaft geared 10.5:1 to the wheel.
+  wheel, one pulse per turn of the spur gear, geared 2.72:1 to the wheel.
   """
   use ExUnit.Case, async: true
 
   alias Decimal, as: D
   alias VmsCore.Components.Traxxas.Motor
 
-  @options %{pulses_per_revolution: 1, gear_ratio: 10.5, wheel_radius: 0.0548}
+  @factor Motor.speed_factor(1, 2.72, 0.0548)
 
   test "no pulses is exactly zero, which is what the standstill gate needs" do
-    assert D.eq?(Motor.speed_km_h(D.new(0), @options), D.new(0))
+    assert D.eq?(Motor.speed_km_h(D.new(0), @factor), D.new(0))
     assert D.eq?(Motor.rotation_per_minute(D.new(0), 1), D.new(0))
   end
 
   test "one wheel turn per second" do
-    # 10.5 pulses per second is one wheel revolution per second:
+    # 2.72 pulses per second is one wheel revolution per second:
     # 2π · 0.0548 m = 0.3443 m/s = 1.24 km/h.
-    speed = Motor.speed_km_h(D.new("10.5"), @options)
-    assert D.eq?(speed, D.new("1.24"))
+    assert D.eq?(Motor.speed_km_h(D.new("2.72"), @factor), D.new("1.24"))
   end
 
-  test "shaft rpm follows pulses per revolution" do
-    assert D.eq?(Motor.rotation_per_minute(D.new("100"), 1), D.new("6000"))
-    assert D.eq?(Motor.rotation_per_minute(D.new("100"), 4), D.new("1500"))
+  test "shaft rpm follows pulses per revolution, as a plain integer" do
+    # `D.div/2` with an integer divisor keeps the exponent at zero, so
+    # the dashboard shows 6000 rather than 6.00E+3.
+    assert D.to_string(Motor.rotation_per_minute(D.new("100"), 1)) == "6000"
+    assert D.to_string(Motor.rotation_per_minute(D.new("100"), 4)) == "1500"
   end
 
   test "more pulses per wheel turn means a slower vehicle for the same frequency" do
-    fast = Motor.speed_km_h(D.new("100"), @options) |> D.to_float()
-    slow = Motor.speed_km_h(D.new("100"), %{@options | pulses_per_revolution: 2}) |> D.to_float()
+    fast = Motor.speed_km_h(D.new("100"), @factor) |> D.to_float()
+    slow = Motor.speed_km_h(D.new("100"), Motor.speed_factor(2, 2.72, 0.0548)) |> D.to_float()
     assert_in_delta slow, fast / 2, 0.01
   end
 end

--- a/vms/core/test/managers/control_level_test.exs
+++ b/vms/core/test/managers/control_level_test.exs
@@ -318,4 +318,32 @@ defmodule VmsCore.Managers.ControlLevelTest do
       assert is_map(state)
     end
   end
+
+  describe "an unknown speed" do
+    test "is not a standstill, so nothing arms" do
+      # The speed source publishes nil while its sensor frame is dead.
+      # Silence must not read as stopped.
+      state =
+        manager()
+        |> deliver(:ready_to_drive, true, Vms)
+        |> deliver(:speed, nil, Abs)
+        |> deliver(:requested_control_level, :radio, RadioLevel)
+        |> tick()
+
+      assert state.selected_control_level == :manual
+    end
+
+    test "is reported as the reason" do
+      log =
+        capture_log(fn ->
+          manager()
+          |> deliver(:ready_to_drive, true, Vms)
+          |> deliver(:speed, nil, Abs)
+          |> deliver(:requested_control_level, :radio, RadioLevel)
+          |> tick()
+        end)
+
+      assert log =~ ":speed_unknown"
+    end
+  end
 end


### PR DESCRIPTION
Stacked on #55. Gives OVCS Mini a `:speed` so the control level manager's standstill gate holds on real hardware.

## What it does

The Mini's motor has a hall effect sensor on the main controller's A1. Until now the controller sampled that pin with `analogRead()` every 10 ms, which for a square wave yields whichever phase the sample lands on and never a rate. Nothing on Mini published `:speed`, so `Managers.ControlLevel` saw zero at all times and allowed every mode change at any speed.

    hall sensor --A1 edges--> controller ISR --0x709 (count, frequency)--> VMS Traxxas.Motor --> :speed, :rotation_per_minute, :moving

- **Controller firmware.** Rising edges on A1 are counted by interrupt, with the pin pulled up: the Traxxas RPM sensor is a hall switch that only pulls the line low. A new frame, `0x7X9`, reports a 16-bit wrapping count and the frequency in tenths of a hertz every 10 ms, only while the pin is enabled. The frequency uses the longer of the last period and the time since the last edge, so a decelerating wheel reads lower on every tick; no edge for two seconds reads as zero, which makes 0.5 Hz (about 0.2 km/h at the wheel) the slowest visible speed and two seconds the delay before the standstill gate reopens. Edges closer than 2 ms are ignored as chatter, since a magnet passed slowly through the switch's threshold toggles it several times. The arithmetic is in `PulseCounter`, tested under the native environment.
- **Adoption frame.** `pulse_pin0` takes bit 53 of `0x700`, previously filler. Every configuration adopted before this has that bit at zero, so existing controllers read it as disabled and behave as before. A1 is shared with analog input 0; when both are enabled the pulse counter takes the pin.
- **VMS.** `GenericController` subscribes to and watches the pulse frame when the vehicle enables the pin, merges its signals with the digital and analog status, publishes them as nil while the frame is not arriving, and refuses a configuration that enables both the pulse counter and analog input 0 on the shared A1. `Traxxas.Motor` turns the frequency into shaft rpm and vehicle speed and publishes `:speed` in km/h: nil until the first frequency arrives and whenever the frame is dead, exactly zero once the controller reports zero. `Managers.ControlLevel` treats nil as not a standstill and refuses the mode change with `:speed_unknown`, so a controller on old firmware or one not yet re-adopted blocks mode changes instead of silently allowing them.
- **Mini.** `Traxxas.Motor` is the manager's `speed_source`. The Dashboard page has a Drivetrain block with the selected level and commander, speed and motor rpm, and a Speed & RPM chart; the controller page shows only the pulse counter's own frequency and count. Merged from #65: the transmitter switches read channels 5, 6 and 7, since ExpressLRS channel 5 is a 2-position arm channel and cannot carry the three-position level.

## OVCS1 is unaffected

OVCS1's ControlsController uses analog input 0, which is the same physical A1, for the throttle pedal. Its configuration declares `pulse_pin0` disabled, and a stored configuration from before this change has the bit at zero, so the pin stays an analog input there. Enabling the pulse counter on that controller would take the pedal's pin, which is why the two cannot be enabled together.

## Estimates, and how to replace them

The trigger magnet sits in the spur gear, so the ratio to the wheel is the Slash 4x4 transmission's fixed 2.72:1, with one pulse per spur turn; the pinion does not enter into it. Both are flagged in the Mini composer. Only their product matters: turn the spur gear until one wheel completes a revolution, count the pulses on `0x709`, and set it. A wrong ratio scales the reported speed; it does not weaken the standstill gate, which only needs zero to be exactly zero.

## Before it works on the vehicle

The sensor needs its own 5 V and ground from the controller, not only the signal wire on A1; without supply it never pulls the line low and the count stays at zero.

1. Reflash the main controller (`pio run -e uno_r4_minima_prod -t upload` in `controllers/generic_controller`).
2. Re-adopt it from the dashboard so its EEPROM carries the new bit.
3. Check `candump can0,709:7FF`: turning the spur gear by hand steps the count once per turn, and the frequency falls to zero within two seconds of stopping. Turn the spur gear rather than a wheel: a loose slipper lets the wheels spin without moving the spur.

## Verification

    controllers/generic_controller   pio test -e local_test: 36 cases pass; pio run -e uno_r4_minima_prod succeeds
    vms/core                         90 tests, 0 failures
    vehicles/ovcs_mini                8 tests, 0 failures
    vehicles/ovcs1, libraries/ovcs_can   compile clean

Format and credo are clean in every touched project. Verified on the vehicle: with the sensor on A1 and powered, turning the spur gear by hand steps the count and shows frequency, rpm and speed on the dashboard, all returning to zero two seconds after it stops.
