### PR TITLE
feat(ovcs_mini): read the switches on channels 5, 6 and 7

### DIFF
--- a/docs/ros2_integration.md
+++ b/docs/ros2_integration.md
@@ -355,10 +355,10 @@ vehicle it is driving.
 two independent switches on the RC transmitter because *authority* and
 *autonomy* are different questions:
 
-| Channel | Component | Values | Answers |
+| Component | Values | Answers | Channel (Mini) |
 |---|---|---|---|
-| 3 | `RadioControl.RequestedControlLevel` | `:manual / :radio / :ros` | who has authority |
-| 5 | `RadioControl.RequestedRosCommander` | `:teleop / :autonomous` | which ROS node, when ROS does |
+| `RadioControl.RequestedControlLevel` | `:manual / :radio / :ros` | who has authority | 6 |
+| `RadioControl.RequestedRosCommander` | `:teleop / :autonomous` | which ROS node, when ROS does | 5 |
 
 `:ros` means "commands come from the ROS bridge". It does not mean the
 car is driving itself — a human on a gamepad and a planner reach the

--- a/docs/vehicle_parameterisation.md
+++ b/docs/vehicle_parameterisation.md
@@ -197,10 +197,13 @@ remsh / `./ovcs attach` flow.
 reads two independent switches on the RC transmitter, because
 authority and autonomy are different questions:
 
-| Component | Values | Channel on Mini | Channel on OVCS1 |
-|---|---|---|---|
-| `OVCS.RadioControl.RequestedControlLevel` | `:manual` / `:radio` / `:ros` | 6 | 3 |
-| `OVCS.RadioControl.RequestedRosCommander` | `:teleop` / `:autonomous` | 5 | not wired |
+| Component | Values |
+|---|---|
+| `OVCS.RadioControl.RequestedControlLevel` | `:manual` / `:radio` / `:ros` |
+| `OVCS.RadioControl.RequestedRosCommander` | `:teleop` / `:autonomous` |
+
+Which transmitter channel each one reads is per vehicle; the layout
+table below is the single place that records it.
 
 `:ros` means the vehicle takes its commands from the ROS bridge. It
 does **not** mean the vehicle is driving itself: a human on a gamepad
@@ -231,12 +234,14 @@ Switch positions are 1000, 1500 and 2000 µs with a margin of 100. A
 position outside every margin falls back to the safe one: `:manual` for
 the level, `:teleop` for the commander, `:forward` for direction.
 
-The Mini's link is ExpressLRS, and that fixes part of the layout:
-channel 5 is the link's arm channel, sent with every packet as a
-2-position value of 1000 or 2000 whatever switch drives it, so it can
-never carry a middle position. Channels 6 to 11 are 3-bit in the
-default Hybrid switch mode and do give 1000, 1500 and 2000. That is why
-the three-position level is on 6 and the two-position commander on 5.
+The Mini's link is ExpressLRS in MAVLink link mode, which forces the
+Hybrid switch mode, and that fixes part of the layout: channel 5 is the
+link's arm channel, sent with every packet as a 2-position value of
+1000 or 2000 whatever switch drives it, so it can never carry a middle
+position. In Hybrid mode channels 6 to 11 are 3-bit and do give 1000,
+1500 and 2000; of those only 6 to 8 reach the bus, since `0x2A1`
+carries channels 5 to 8. That is why the three-position level is on 6
+and the two-position commander on 5.
 
 ### The source maps
 
@@ -268,10 +273,25 @@ receiver: `radio_control_bridge_config(:host)` declares no components,
 so nothing emits `0x2A1`/`0x2A0` and the level never leaves `:manual`.
 Joystick input still reaches `0x2B0`/`0x2B1` and is discarded.
 
-So a bench session needs the switches synthesised. `0x2A0` carries
-channels 1-4 as little-endian `uint16`, two bytes each; `0x2A1`
-carries 5-8 the same way. 1500 is `DC05`, 2000 is `D007`, 1000 is
-`E803`:
+There is no controller on the host either, so nothing emits the pulse
+counter frame `0x709`. The generic controller publishes the pulse
+frequency as nil while that frame is dead, `Traxxas.Motor` publishes a
+nil speed, and the manager treats an unknown speed as "not a
+standstill": every mode change is refused with `:speed_unknown`. So a
+bench session needs two things synthesised, a speed and the switches.
+
+The speed first, and it has to be a stream: the frame watcher needs
+several on-time frames to declare `0x709` alive and drops it again as
+soon as they stop. Leave this running in its own terminal; a count and
+a frequency of zero is a stationary vehicle:
+
+```bash
+cangen vcan0 -I 709 -L 4 -D 00000000 -g 10
+```
+
+Then the switches. `0x2A0` carries channels 1-4 as little-endian
+`uint16`, two bytes each; `0x2A1` carries 5-8 the same way. 1500 is
+`DC05`, 2000 is `D007`, 1000 is `E803`:
 
 ```bash
 # Steering and throttle centred (channels 1 and 2)
@@ -285,17 +305,18 @@ cansend vcan0 2A1#E803DC0500000000
 cansend vcan0 2A1#E803D00700000000
 
 # Optional: hand it to the planner rather than the gamepad
-# (channel 5 = 2000). Needs a standstill, which the host always is.
+# (channel 5 = 2000). Needs a standstill, which the zero speed
+# stream above provides.
 cansend vcan0 2A1#D007D00700000000
 ```
 
 Channels 7 and 8 read as 0 in these frames, which is outside every
-switch margin and therefore the safe fallback. The frames above are the
-Mini's layout; on OVCS1 the level is channel 3, in `0x2A0`.
+switch margin and therefore the safe fallback. The frames are the
+Mini's layout; the table above has the other vehicles'.
 
-`ready_to_drive` is hardcoded `true` on Mini (`OvcsMini.Vms`), so
-nothing else is needed there. On a vehicle whose `ready_to_drive`
-comes from contactors or an inverter, that has to be true as well.
+`ready_to_drive` is hardcoded `true` on Mini (`OvcsMini.Vms`). On a
+vehicle whose `ready_to_drive` comes from contactors or an inverter,
+that has to be true as well.
 
 ## Host dev vs. deployed
 

--- a/docs/vehicle_parameterisation.md
+++ b/docs/vehicle_parameterisation.md
@@ -197,16 +197,16 @@ remsh / `./ovcs attach` flow.
 reads two independent switches on the RC transmitter, because
 authority and autonomy are different questions:
 
-| Channel | Component | Values |
-|---|---|---|
-| 3 | `OVCS.RadioControl.RequestedControlLevel` | `:manual` / `:radio` / `:ros` |
-| 5 | `OVCS.RadioControl.RequestedRosCommander` | `:teleop` / `:autonomous` |
+| Component | Values | Channel on Mini | Channel on OVCS1 |
+|---|---|---|---|
+| `OVCS.RadioControl.RequestedControlLevel` | `:manual` / `:radio` / `:ros` | 6 | 3 |
+| `OVCS.RadioControl.RequestedRosCommander` | `:teleop` / `:autonomous` | 5 | not wired |
 
 `:ros` means the vehicle takes its commands from the ROS bridge. It
 does **not** mean the vehicle is driving itself: a human on a gamepad
 and a planner reach the VMS over the same topics and the same CAN
-frames. Which of them has the wheel is channel 5's answer, and it is
-why the level is named `:ros` rather than `:autonomous`.
+frames. Which of them has the wheel is the commander switch's answer,
+and it is why the level is named `:ros` rather than `:autonomous`.
 
 Both switches only *request*. The manager decides, and refuses moves
 that are unsafe — in motion, not ready to drive, or while a fault has
@@ -214,16 +214,29 @@ forced a lower level. `:ros` is reachable only from `:radio`, so
 getting there is two deliberate throws with the middle position in
 between. A request it cannot honour is logged once, with the reason.
 
-The full channel convention, shared by every vehicle so a transmitter
-set up for one reads the same way on another:
+The full channel layout per vehicle. Channel numbers are the
+transmitter's own: the radio control bridge copies the receiver's
+channels 1-8 onto `0x2A0` and `0x2A1` unchanged, and each composer
+names the channel every component reads.
 
-| Channel | Purpose |
-|---|---|
-| 1 | Steering |
-| 2 | Throttle (and `radio_breaking`, the human takeover) |
-| 3 | Control level |
-| 4 | Direction (OVCS1; unused on Mini) |
-| 5 | ROS commander |
+| Purpose | Mini | OVCS1 |
+|---|---|---|
+| Steering | 1 | 1 |
+| Throttle (and `radio_breaking`, the human takeover) | 2 | 2 |
+| Control level | 6 | 3 |
+| Direction | 7 (published, no actuator reads it) | 4 |
+| ROS commander | 5 | not wired |
+
+Switch positions are 1000, 1500 and 2000 µs with a margin of 100. A
+position outside every margin falls back to the safe one: `:manual` for
+the level, `:teleop` for the commander, `:forward` for direction.
+
+The Mini's link is ExpressLRS, and that fixes part of the layout:
+channel 5 is the link's arm channel, sent with every packet as a
+2-position value of 1000 or 2000 whatever switch drives it, so it can
+never carry a middle position. Channels 6 to 11 are 3-bit in the
+default Hybrid switch mode and do give 1000, 1500 and 2000. That is why
+the three-position level is on 6 and the two-position commander on 5.
 
 ### The source maps
 
@@ -250,7 +263,7 @@ nobody asked for. Such a vehicle also omits
 
 `Managers.ControlLevel` starts in `default_control_level` — `:manual`
 on OVCS Mini, where every source is `nil`, so **nothing commands the
-vehicle until channel 3 says otherwise**. On the host there is no RC
+vehicle until channel 6 says otherwise**. On the host there is no RC
 receiver: `radio_control_bridge_config(:host)` declares no components,
 so nothing emits `0x2A1`/`0x2A0` and the level never leaves `:manual`.
 Joystick input still reaches `0x2B0`/`0x2B1` and is discarded.
@@ -261,17 +274,24 @@ carries 5-8 the same way. 1500 is `DC05`, 2000 is `D007`, 1000 is
 `E803`:
 
 ```bash
-# Steering and throttle centred, level -> :radio (channel 3 = 1500)
-cansend vcan0 2A0#DC05DC05DC050000
+# Steering and throttle centred (channels 1 and 2)
+cansend vcan0 2A0#DC05DC0500000000
 
-# ... then level -> :ros (channel 3 = 2000). Two steps, in this order:
+# Level -> :radio (channel 6 = 1500; channel 5 = 1000 keeps :teleop)
+cansend vcan0 2A1#E803DC0500000000
+
+# ... then level -> :ros (channel 6 = 2000). Two steps, in this order:
 # :ros is only reachable from :radio.
-cansend vcan0 2A0#DC05DC05D0070000
+cansend vcan0 2A1#E803D00700000000
 
 # Optional: hand it to the planner rather than the gamepad
 # (channel 5 = 2000). Needs a standstill, which the host always is.
-cansend vcan0 2A1#D007000000000000
+cansend vcan0 2A1#D007D00700000000
 ```
+
+Channels 7 and 8 read as 0 in these frames, which is outside every
+switch margin and therefore the safe fallback. The frames above are the
+Mini's layout; on OVCS1 the level is channel 3, in `0x2A0`.
 
 `ready_to_drive` is hardcoded `true` on Mini (`OvcsMini.Vms`), so
 nothing else is needed there. On a vehicle whose `ready_to_drive`

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -83,12 +83,13 @@ defmodule OvcsMini.Vms.Composer do
       # decides, which is the whole reason they route through it rather
       # than being read where the actuators are wired.
       #
-      # This is the Mini transmitter's layout over ExpressLRS: sticks on
-      # 1 and 2, switches from 5 up, 3 and 4 unused. Channel 5 is the
-      # link's 2-position arm channel and cannot carry a middle
-      # position, so the three-position level goes on 6 and the
-      # two-position commander takes 5. OVCS1 puts the level on 3 and
-      # direction on 4; docs/vehicle_parameterisation.md has both.
+      # This is the Mini transmitter's layout over ExpressLRS in MAVLink
+      # link mode, which forces the Hybrid switch mode: sticks on 1 and
+      # 2, switches from 5 up, 3 and 4 unused. Channel 5 is the link's
+      # 2-position arm channel and cannot carry a middle position, so
+      # the three-position level goes on 6 and the two-position
+      # commander takes 5. docs/vehicle_parameterisation.md has the
+      # layout of every vehicle.
       {OVCS.RadioControl.RequestedControlLevel,
        %{
          radio_control_channel: 6
@@ -97,10 +98,10 @@ defmodule OvcsMini.Vms.Composer do
        %{
          radio_control_channel: 5
        }},
-      # Wired and published, but no actuator on the Mini reads a
-      # direction: reverse is a negative throttle here. It is the radio
-      # direction source so the value shows up on the bus and the
-      # dashboard, and so a drivetrain that needs it can take it later.
+      # Started so the value is published; no actuator on the Mini
+      # reads a direction, since reverse is a negative throttle here.
+      # Named as the radio source below so a drivetrain that consumes
+      # direction can be wired without touching the manager.
       {OVCS.RadioControl.Direction,
        %{
          radio_control_channel: 7
@@ -147,9 +148,10 @@ defmodule OvcsMini.Vms.Composer do
          # `radio_control_bridge_config(:host)` declares no components,
          # so nothing emits 0x2A0/0x2A1, channel 6 stays at its default
          # 1000, and joystick input on 0x2B0/0x2B1 is discarded with no
-         # log. Synthesise the switches with `cansend` --
-         # docs/vehicle_parameterisation.md, "Driving on the host
-         # bench", has the frames.
+         # log. Nothing emits the pulse counter frame either, so the
+         # speed is unknown and the manager refuses every mode change
+         # until one is synthesised. docs/vehicle_parameterisation.md,
+         # "Driving on the host bench", has the frames for both.
          default_control_level: :manual,
          ready_to_drive_source: Vms,
          # The standstill gate on every mode change reads this. It is

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -77,22 +77,33 @@ defmodule OvcsMini.Vms.Composer do
        %{
          radio_control_channel: 2
        }},
-      # Two switches, two questions. Channel 3 says who has authority,
+      # Two switches, two questions. Channel 6 says who has authority,
       # channel 5 says which ROS node commands when ROS does — see
       # `Managers.ControlLevel`. Both only *request*; the manager
       # decides, which is the whole reason they route through it rather
       # than being read where the actuators are wired.
       #
-      # Channel 3 for authority, with 4 left free for direction, is the
-      # OVCS1 convention — so a transmitter set up for one vehicle
-      # reads the same way on the other.
+      # This is the Mini transmitter's layout over ExpressLRS: sticks on
+      # 1 and 2, switches from 5 up, 3 and 4 unused. Channel 5 is the
+      # link's 2-position arm channel and cannot carry a middle
+      # position, so the three-position level goes on 6 and the
+      # two-position commander takes 5. OVCS1 puts the level on 3 and
+      # direction on 4; docs/vehicle_parameterisation.md has both.
       {OVCS.RadioControl.RequestedControlLevel,
        %{
-         radio_control_channel: 3
+         radio_control_channel: 6
        }},
       {OVCS.RadioControl.RequestedRosCommander,
        %{
          radio_control_channel: 5
+       }},
+      # Wired and published, but no actuator on the Mini reads a
+      # direction: reverse is a negative throttle here. It is the radio
+      # direction source so the value shows up on the bus and the
+      # dashboard, and so a drivetrain that needs it can take it later.
+      {OVCS.RadioControl.Direction,
+       %{
+         radio_control_channel: 7
        }},
       {Managers.ControlLevel,
        %{
@@ -108,7 +119,7 @@ defmodule OvcsMini.Vms.Composer do
          # does, because its throttle axis is unsigned.
          requested_direction_sources: %{
            manual: nil,
-           radio: nil,
+           radio: OVCS.RadioControl.Direction,
            ros: %{teleop: OVCS.ROSControl.Direction, autonomous: nil}
          },
          requested_throttle_sources: %{
@@ -134,7 +145,7 @@ defmodule OvcsMini.Vms.Composer do
          #
          # On the host bench that means nothing commands it at all:
          # `radio_control_bridge_config(:host)` declares no components,
-         # so nothing emits 0x2A0/0x2A1, channel 3 stays at its default
+         # so nothing emits 0x2A0/0x2A1, channel 6 stays at its default
          # 1000, and joystick input on 0x2B0/0x2B1 is discarded with no
          # log. Synthesise the switches with `cansend` --
          # docs/vehicle_parameterisation.md, "Driving on the host

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/radio_control_page.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/radio_control_page.ex
@@ -21,9 +21,15 @@ defmodule OvcsMini.Vms.Composer.Dashboard.RadioControlPage do
             },
             %{
               type: :metric,
-              name: "Requested Gear",
-              module: RadioControl.Gear,
-              key: :requested_gear
+              name: "Requested ROS Commander",
+              module: RadioControl.RequestedRosCommander,
+              key: :requested_ros_commander
+            },
+            %{
+              type: :metric,
+              name: "Requested Direction",
+              module: RadioControl.Direction,
+              key: :requested_direction
             },
             %{
               type: :metric,


### PR DESCRIPTION
Stacked on #64. Moves the Mini's transmitter switches to channels an ExpressLRS link can actually carry, and wires direction.

## Why

ExpressLRS reserves channel 5 as the arm channel: it is sent with every packet as a single bit, so it only ever reads 1000 or 2000, whatever switch drives it in EdgeTX. The Mini's link runs in MAVLink link mode, which forces the Hybrid switch mode; there, channels 6 to 11 are 3-bit and give 1000, 1500 and 2000, and of those only 6 to 8 reach the bus on `0x2A1`. A three-position control level on channel 5 therefore has no middle position and `:radio` is unreachable, which makes `:ros` unreachable too since it is only entered from `:radio`.

## New layout on the Mini

| Purpose | Channel | Positions |
|---|---|---|
| Steering | 1 | stick |
| Throttle | 2 | stick |
| ROS commander | 5 | 1000 `:teleop`, 2000 `:autonomous` |
| Control level | 6 | 1000 `:manual`, 1500 `:radio`, 2000 `:ros` |
| Direction | 7 | 1000 `:forward`, 2000 `:backward` |

Channels 3 and 4 are unused on the Mini. OVCS1 is untouched and keeps the level on 3 and direction on 4; the docs now show both layouts side by side. The host bench recipe uses the Mini's channels on `0x2A1` and starts with a zero-speed `0x709` stream from `cangen`: with no controller on the host the speed is unknown and the manager refuses every mode change until one is synthesised.

`RadioControl.Direction` is started on channel 7 and is the radio direction source. Nothing on the Mini's drivetrain reads a direction, reverse being a negative throttle, so it is published on the bus and the dashboard without driving anything. The Radio Control dashboard page shows the requested commander and direction; it previously had a "Requested Gear" row bound to a `RadioControl.Gear` module that does not exist.

## Verified on the vehicle

With the transmitter's switches assigned accordingly, channel 6 steps the level `:manual` → `:radio` → `:ros` with 1500 in the middle, channel 5 selects the commander and is inert outside `:ros`, and channel 7 shows the direction. A level switch left at 2000 from `:manual` is refused and logged, as designed.

A VMS redeploy starves the main controller of the alive frame long enough for it to shut down into `VMS_MISSING_ERROR`. In that state it emits no pulse frame, the speed publishes as nil, and the manager refuses every mode change until the dashboard's **Reset status** action brings the controller back. The VMS does not reset controllers at boot; that is pre-existing and worth a follow-up.

## Verification

    vehicles/ovcs_mini    8 tests, 0 failures, compile clean with warnings as errors
    vms/core             manager tests 30, 0 failures

Sources: [ExpressLRS switch configuration](https://www.expresslrs.org/software/switch-config/).
