### PR TITLE
fix: zero the throttle when the level commands nothing

### DIFF
--- a/vms/core/lib/vms_core/components/bosch/i_booster_gen2.ex
+++ b/vms/core/lib/vms_core/components/bosch/i_booster_gen2.ex
@@ -159,7 +159,19 @@ defmodule VmsCore.Components.Bosch.IBoosterGen2 do
         state
       )
       when source == state.selected_control_level_source do
-    {:noreply, %{state | requested_throttle_source: requested_throttle_source}}
+    # Zero on the way to a level that commands nothing. The
+    # `:requested_throttle` handler gates on the source, so with no
+    # source no message matches and a held negative request would keep
+    # the automatic braking applied. The pedal is unaffected: it acts
+    # on the booster mechanically.
+    requested = if is_nil(requested_throttle_source), do: @zero, else: state.requested_throttle
+
+    {:noreply,
+     %{
+       state
+       | requested_throttle_source: requested_throttle_source,
+         requested_throttle: requested
+     }}
   end
 
   def handle_info(

--- a/vms/core/lib/vms_core/components/bosch/i_booster_gen2.ex
+++ b/vms/core/lib/vms_core/components/bosch/i_booster_gen2.ex
@@ -187,14 +187,6 @@ defmodule VmsCore.Components.Bosch.IBoosterGen2 do
     {:noreply, %{state | contact: contact}}
   end
 
-  def handle_info(
-        %Bus.Message{name: :requested_throttle, value: requested_throttle, source: source},
-        state
-      )
-      when source == state.requested_throttle_source do
-    {:noreply, %{state | requested_throttle: requested_throttle}}
-  end
-
   def handle_info(%Bus.Message{}, state) do
     {:noreply, state}
   end

--- a/vms/core/lib/vms_core/components/nissan/leaf_aze0/inverter.ex
+++ b/vms/core/lib/vms_core/components/nissan/leaf_aze0/inverter.ex
@@ -110,7 +110,20 @@ defmodule VmsCore.Components.Nissan.LeafAZE0.Inverter do
         state
       )
       when source == state.selected_control_level_source do
-    {:noreply, %{state | requested_throttle_source: requested_throttle_source}}
+    # Zero on the way to a level that commands nothing. The
+    # `:requested_throttle` handler gates on the source, so with no
+    # source no message matches and the last request would be held --
+    # and applied as torque every tick. A vehicle that keeps pulling
+    # after being switched to a safe level is the same hazard as a
+    # stale CAN frame.
+    requested = if is_nil(requested_throttle_source), do: @zero, else: state.requested_throttle
+
+    {:noreply,
+     %{
+       state
+       | requested_throttle_source: requested_throttle_source,
+         requested_throttle: requested
+     }}
   end
 
   def handle_info(

--- a/vms/core/lib/vms_core/managers/gear.ex
+++ b/vms/core/lib/vms_core/managers/gear.ex
@@ -94,7 +94,18 @@ defmodule VmsCore.Managers.Gear do
         state
       )
       when source == state.selected_control_level_source do
-    {:noreply, %{state | requested_throttle_source: requested_throttle_source}}
+    # Zero on the way to a level that commands nothing. The
+    # `:requested_throttle` handler gates on the source, so with no
+    # source no message matches and a held positive request would keep
+    # refusing gear changes that are actually safe.
+    requested = if is_nil(requested_throttle_source), do: @zero, else: state.requested_throttle
+
+    {:noreply,
+     %{
+       state
+       | requested_throttle_source: requested_throttle_source,
+         requested_throttle: requested
+     }}
   end
 
   def handle_info(

--- a/vms/core/test/components/throttle_source_switching_test.exs
+++ b/vms/core/test/components/throttle_source_switching_test.exs
@@ -1,0 +1,71 @@
+defmodule VmsCore.Components.ThrottleSourceSwitchingTest do
+  @moduledoc """
+  Every consumer of `:requested_throttle` stops acting on it when
+  `Managers.ControlLevel` names no source.
+
+  The handler for `:requested_throttle` gates on the source, so with a
+  nil source no message matches and the last request would be held.
+  Held in the inverter it is applied as torque every tick; held in the
+  brake booster a negative request keeps the automatic braking on. Each
+  consumer therefore zeroes the request on the way to a level that
+  commands nothing.
+
+  Driven through `handle_info/2` against a stub state, the way
+  `VmsCore.Managers.GearTest` does: the transition is the subject, not
+  the CAN stack `init/1` would need.
+  """
+  use ExUnit.Case, async: true
+
+  alias Decimal, as: D
+  alias OvcsBus.Message
+  alias VmsCore.Components.Bosch.IBoosterGen2
+  alias VmsCore.Components.Nissan.LeafAZE0.Inverter
+
+  @manager ControlLevelManager
+  @commander SomeCommander
+
+  defp state(overrides \\ %{}) do
+    Map.merge(
+      %{
+        selected_control_level_source: @manager,
+        requested_throttle_source: @commander,
+        requested_throttle: D.new("0.6")
+      },
+      overrides
+    )
+  end
+
+  defp source_message(value, source),
+    do: %Message{name: :requested_throttle_source, value: value, source: source}
+
+  for module <- [Inverter, IBoosterGen2] do
+    describe "#{inspect(module)} on a level that commands nothing" do
+      test "zeroes the throttle rather than holding it" do
+        {:noreply, state} =
+          unquote(module).handle_info(source_message(nil, @manager), state())
+
+        assert state.requested_throttle_source == nil
+
+        assert D.eq?(state.requested_throttle, D.new(0)),
+               "the last throttle survived a switch to a level with no commander"
+      end
+
+      test "keeps the request across a switch between commanders" do
+        {:noreply, state} =
+          unquote(module).handle_info(source_message(AnotherCommander, @manager), state())
+
+        assert state.requested_throttle_source == AnotherCommander
+        assert D.eq?(state.requested_throttle, D.new("0.6"))
+      end
+
+      test "ignores a source named by anything but the manager" do
+        original = state()
+
+        {:noreply, state} =
+          unquote(module).handle_info(source_message(Impostor, NotTheManager), original)
+
+        assert state == original
+      end
+    end
+  end
+end

--- a/vms/core/test/managers/gear_test.exs
+++ b/vms/core/test/managers/gear_test.exs
@@ -57,6 +57,52 @@ defmodule VmsCore.Managers.GearTest do
     end
   end
 
+  describe "a level that commands no throttle" do
+    test "zeroes the held request rather than gating gear changes on it" do
+      # With a nil source no `:requested_throttle` message matches, so
+      # a held positive request would refuse gear changes for ever.
+      state =
+        stub_state(%{
+          requested_throttle_source: Driver,
+          requested_throttle: Decimal.new("0.6")
+        })
+
+      {:noreply, state} =
+        Gear.handle_info(
+          %Message{
+            name: :requested_throttle_source,
+            value: nil,
+            source: @control_level_source
+          },
+          state
+        )
+
+      assert state.requested_throttle_source == nil
+      assert Decimal.eq?(state.requested_throttle, Decimal.new(0))
+    end
+
+    test "a switch between commanders keeps the request" do
+      state =
+        stub_state(%{
+          requested_throttle_source: Driver,
+          requested_throttle: Decimal.new("0.6")
+        })
+
+      {:noreply, state} =
+        Gear.handle_info(
+          %Message{
+            name: :requested_throttle_source,
+            value: AnotherDriver,
+            source: @control_level_source
+          },
+          state
+        )
+
+      assert state.requested_throttle_source == AnotherDriver
+      assert Decimal.eq?(state.requested_throttle, Decimal.new("0.6"))
+    end
+  end
+
   describe "requested_gear vs requested_direction" do
     test "requested_gear updates state when the gear-source path is active" do
       state = stub_state(%{requested_gear_source: Driver})


### PR DESCRIPTION
`Managers.ControlLevel` selects sources per control level, and a level with no throttle commander selects nil. Every consumer's `:requested_throttle` handler gates on the source, so with a nil source no message matches and the last request is held, silently.

What the held value does depends on the consumer:

| Consumer | A held request means |
|---|---|
| `Nissan.LeafAZE0.Inverter` | the last throttle is applied as torque every tick — the vehicle keeps pulling after being switched to a safe level |
| `Bosch.IBoosterGen2` | a negative request keeps the automatic braking applied (the pedal is unaffected; it acts on the booster mechanically) |
| `Managers.Gear` | a positive request refuses gear changes for ever |

Each consumer now zeroes the request in the handler that learns about the switch, so the safe level is safe the moment it is selected. A switch between two commanders keeps the request: the incoming commander's own messages overwrite it immediately.

The steering column deliberately holds instead: snapping the wheels straight mid-corner is a hazard, not a mitigation, so an uncommanded steering keeps its last angle the way an uncommanded throttle must not keep its last torque.

`Managers.Gear` gates `requested_gear` and `requested_direction` on their sources the same way, so those are also held when a level names no source for them. A held gear request is benign by comparison: every gear change is additionally gated on a standstill, a near-zero throttle and `ready_to_drive`, so the worst case is a gear re-engaged at rest rather than torque applied in motion. Left as is.

`IBoosterGen2` carried two identical `:requested_throttle` clauses; the unreachable second one is removed in passing.

Not reachable on OVCS1 as composed today — its throttle sources have no nil entry — so this is a latent property of the platform rather than a live fault: any composer that leaves a level's throttle uncommanded gets the holding behaviour.

## Verification

    vms/core   109 tests, 0 failures (merged onto main)

The nine new tests drive `handle_info/2` directly and fail against the previous handlers. `mix compile --warnings-as-errors`, `mix format --check-formatted` and `credo --strict` are clean.
