### PR TITLE
chore: remove the test backdoors from the Traxxas actuators

### DIFF
--- a/vms/core/lib/vms_core/components/traxxas/steering.ex
+++ b/vms/core/lib/vms_core/components/traxxas/steering.ex
@@ -104,15 +104,4 @@ defmodule VmsCore.Components.Traxxas.Steering do
         %{state | steering: state.requested_steering}
     end
   end
-
-  # TODO remove
-  @impl true
-  def handle_call({:test_request_steering, value}, _from, state) do
-    {:reply, :ok, %{state | requested_steering: value}}
-  end
-
-  # TODO remove
-  def test_request_steering(value) do
-    GenServer.call(__MODULE__, {:test_request_steering, value})
-  end
 end

--- a/vms/core/lib/vms_core/components/traxxas/throttle.ex
+++ b/vms/core/lib/vms_core/components/traxxas/throttle.ex
@@ -140,15 +140,4 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   @doc false
   def shape(requested, true = _linear), do: requested
   def shape(requested, false), do: requested |> D.abs() |> D.mult(requested)
-
-  # TODO remove
-  @impl true
-  def handle_call({:test_request_throttle, value}, _from, state) do
-    {:reply, :ok, %{state | requested_throttle: value}}
-  end
-
-  # TODO remove
-  def test_request_throttle(value) do
-    GenServer.call(__MODULE__, {:test_request_throttle, value})
-  end
 end


### PR DESCRIPTION
On top of #55.

`Traxxas.Throttle.test_request_throttle/1` and `Traxxas.Steering.test_request_steering/1` wrote a request straight into the actuator's state through a `GenServer.call`, bypassing the source attribution everything else is built on: any process could command an actuator without being the source `Managers.ControlLevel` selected. They were bench scaffolding, marked `# TODO remove`, and nothing in the repo calls them.

While confirming what else remained open from #55's "Before the first planner drive" list, two of its points turned out to be already resolved on the branch and are worth striking from that list:

- **Point 3 (`ReceivedFrameWatcher` re-poisoning).** `ros_velocity_command` (`0x2B1`) carries a `sequence` and `RosVelocityCommand` runs it through `RosCommand.Freshness` with a 300 ms timeout — the same mechanism as the actuator-command path. A stray frame after an outage reloads the velocity once, then it goes stale and is zeroed within 300 ms; nothing is "applied indefinitely". No `ReceivedFrameWatcher` watches this frame anymore, and cantastic's `allowed_frequency_leeway` is per-frame configurable in the YAML in any case.
- **Point 4 (steering-centring asserted both ways).** The nil-source clause in `Traxxas.Steering` holds the last angle and `source_switching_test.exs` codifies holding. Code, tests and moduledocs agree; there is nothing left to pick.

## Verification

    vms/core   101 tests, 0 failures

`mix compile --warnings-as-errors` and `mix format --check-formatted` are clean; `credo --strict` drops from seven design suggestions to three, all pre-existing.