### PR TITLE
Make the Traxxas throttle start gently and tunable

### DIFF
--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -28,6 +28,11 @@ defmodule OvcsMini.Vms.Composer do
   # 13 m/s, but nothing has measured this one under load.
   @max_speed_m_s 5.0
 
+  # Throttle feel, see `Traxxas.Throttle` for what each one does.
+  @throttle_deadzone Decimal.new("0.05")
+  @throttle_expo Decimal.new("0.5")
+  @throttle_start_offset Decimal.new("0.06")
+
   # The trigger magnet sits in the spur gear, so wheel speed needs the
   # ratio from the spur gear to the wheels: the Slash 4x4 transmission's
   # fixed 2.72:1. The pinion does not enter into it. One magnet, one
@@ -179,8 +184,25 @@ defmodule OvcsMini.Vms.Composer do
          external_pwm_id: 1,
          selected_control_level_source: Managers.ControlLevel,
          # A velocity is a physical quantity, not a hand on a trigger:
-         # it bypasses the joystick feel curve.
-         linear_sources: [OVCS.RosVelocityCommand]
+         # it bypasses the dead zone, the feel curve and the start
+         # offset below.
+         linear_sources: [OVCS.RosVelocityCommand],
+         # The trigger at rest drifts by up to 20 counts of 500, and
+         # the joystick node's own dead zone is the same 5%. Matches
+         # `RadioControl.Throttle`'s braking threshold, so a trigger
+         # that reads as braking also reads as a request here.
+         deadzone: @throttle_deadzone,
+         # Half way between linear and the full square: enough
+         # flattening for fine control at low speed without pushing
+         # the edge of motion a third of the way along the trigger.
+         expo: @throttle_expo,
+         # ESTIMATE: the throttle output at which the wheels first
+         # move. The radio control page shows the request, not the
+         # output, so the reading has to be run through the curve in
+         # force when it was taken. Too low only wastes a little
+         # travel; too high makes the first touch a jump, so it starts
+         # conservative.
+         start_offset: @throttle_start_offset
        }},
       {OVCS.PulseSpeedSensor,
        %{

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -22,16 +22,24 @@ defmodule OvcsMini.Vms.Composer do
   def default_can_mapping(:host), do: "ovcs:vcan0"
   def default_can_mapping(:target), do: "ovcs:spi0.0"
 
-  # Full throttle in m/s. Not geometry — a property of the motor and
-  # gearing, not a measured dimension of the chassis. ESTIMATE: a stock
-  # Slash 4x4 does roughly 30 mph, and the simulated model is capped at
-  # 13 m/s, but nothing has measured this one under load.
-  @max_speed_m_s 5.0
+  # Speed in m/s at the throttle cap below, which is what a full request
+  # from the planner produces. Not geometry — a property of the motor,
+  # the gearing and the cap, not a measured dimension of the chassis.
+  # ESTIMATE: a stock Slash 4x4 does roughly 30 mph and the simulated
+  # model is capped at 13 m/s; the uncapped truck was estimated at
+  # 5 m/s and this is half of it, but nothing has measured this one
+  # under load.
+  @max_speed_m_s 2.5
 
   # Throttle feel, see `Traxxas.Throttle` for what each one does.
   @throttle_deadzone Decimal.new("0.05")
   @throttle_expo Decimal.new("0.5")
   @throttle_start_offset Decimal.new("0.06")
+  # Half the pulse range forward. The uncapped truck is far too fast for
+  # where it drives; the reverse side stays at 1 because on this ESC the
+  # first pull into negative is the brake.
+  @throttle_max Decimal.new("0.5")
+  @throttle_max_reverse Decimal.new("1")
 
   # The trigger magnet sits in the spur gear, so wheel speed needs the
   # ratio from the spur gear to the wheels: the Slash 4x4 transmission's
@@ -185,7 +193,8 @@ defmodule OvcsMini.Vms.Composer do
          selected_control_level_source: Managers.ControlLevel,
          # A velocity is a physical quantity, not a hand on a trigger:
          # it bypasses the dead zone, the feel curve and the start
-         # offset below.
+         # offset below, and only gets the cap. `@max_speed_m_s` is the
+         # speed at that cap for that reason.
          linear_sources: [OVCS.RosVelocityCommand],
          # The trigger at rest drifts by up to 20 counts of 500, and
          # the joystick node's own dead zone is the same 5%. Matches
@@ -202,7 +211,9 @@ defmodule OvcsMini.Vms.Composer do
          # force when it was taken. Too low only wastes a little
          # travel; too high makes the first touch a jump, so it starts
          # conservative.
-         start_offset: @throttle_start_offset
+         start_offset: @throttle_start_offset,
+         max_throttle: @throttle_max,
+         max_reverse: @throttle_max_reverse
        }},
       {OVCS.PulseSpeedSensor,
        %{

--- a/vms/core/lib/vms_core/components/traxxas/throttle.ex
+++ b/vms/core/lib/vms_core/components/traxxas/throttle.ex
@@ -2,18 +2,42 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   @moduledoc """
     Traxxas' ESC throttle controlled by a PWM signal
 
-  ## The feel curve
+  ## From request to pulse
 
-  A joystick or trigger request is squared (keeping its sign) before it
-  becomes a duty cycle, so small deflections give fine control and full
-  deflection still gives full power. That is a property of a *hand* on
-  an axis, not of the actuator: a commander that sends a physical
-  quantity -- `RosVelocityCommand` normalises metres per second --
-  expects the request applied as is, or a planner asking for a fifth of
-  full speed gets a twenty-fifth.
+  A request in [-1, 1] goes through up to three steps before it becomes
+  a duty cycle. All three are tunable per vehicle; the defaults are no
+  dead zone, the full square and no start offset.
 
-  `:linear_sources` lists the sources whose request is already a
-  physical quantity. Every other source goes through the curve.
+  1. **Dead zone** (`:deadzone`). A hand at rest is not exactly at
+     centre: a trigger drifts by a few counts, a gamepad stick by a few
+     percent. Requests within `deadzone` of centre read as zero, and the
+     rest of the travel is stretched back over [0, 1] so nothing is
+     lost at the far end. Without it the start offset below would turn
+     that drift into a creeping vehicle.
+  2. **Feel curve** (`:expo`). A blend between the raw position and its
+     signed square: `expo` 0 is linear, 1 is the full square. Squaring
+     flattens the middle of the travel for fine control at low speed,
+     but the flatter the curve, the further along the stick the ESC's
+     minimum useful pulse sits — the square alone puts it past a third
+     of the travel, which reads as a dead band followed by an abrupt
+     start.
+  3. **Start offset** (`:start_offset`). An ESC and a motor need a
+     minimum pulse before anything turns; below it the request is
+     silently wasted. Every non-zero output is remapped from [0, 1]
+     onto [start_offset, 1], so the first perceptible input already sits
+     at the edge of motion and the rest of the travel is spent on
+     speeds the vehicle can actually take. Set it to the throttle
+     *output* at which the wheels first move -- the value written to
+     the ESC, not the request shown on the dashboard.
+
+  All three are properties of a *hand* on an axis, not of the actuator.
+  A commander that sends a physical quantity -- `RosVelocityCommand`
+  normalises metres per second -- expects its request applied as is, or
+  a planner asking for a fifth of full speed gets a twenty-fifth, and a
+  planner decelerating through a tiny velocity expects the vehicle to
+  follow it down rather than hold the edge of motion. `:linear_sources`
+  lists the sources whose request is already a physical quantity: they
+  skip all three steps.
   """
   use GenServer
   alias Decimal, as: D
@@ -25,6 +49,9 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   @neutral_duty_cycle_percentage D.new("0.15")
   @duty_cycle_percentage_range D.new("0.05")
   @zero D.new(0)
+  @one D.new(1)
+
+  @default_curve %{deadzone: @zero, expo: @one, start_offset: @zero}
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
@@ -48,6 +75,7 @@ defmodule VmsCore.Components.Traxxas.Throttle do
        external_pwm_id: external_pwm_id,
        selected_control_level_source: selected_control_level_source,
        linear_sources: Map.get(args, :linear_sources, []),
+       curve: curve(args),
        # Starts nil: nothing commands this actuator until the manager
        # names a source. The manager's default level does that on its
        # first tick.
@@ -110,7 +138,11 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   # reach the PWM.
   defp apply_throttle(state) do
     throttle =
-      shape(state.requested_throttle, state.requested_throttle_source in state.linear_sources)
+      shape(
+        state.requested_throttle,
+        state.requested_throttle_source in state.linear_sources,
+        state.curve
+      )
 
     case D.eq?(state.throttle, throttle) do
       true ->
@@ -135,9 +167,81 @@ defmodule VmsCore.Components.Traxxas.Throttle do
     end
   end
 
-  # Signed square: `requested * |requested|` keeps the sign and the
-  # endpoints while flattening the middle of the travel.
-  @doc false
-  def shape(requested, true = _linear), do: requested
-  def shape(requested, false), do: requested |> D.abs() |> D.mult(requested)
+  @doc """
+  The curve parameters from a component's arguments, each defaulting to
+  the value that leaves the request untouched. Fractions of full travel,
+  all in [0, 1]; `deadzone + start_offset` must stay below 1.
+  """
+  def curve(args) do
+    curve = Map.merge(@default_curve, Map.take(args, Map.keys(@default_curve)))
+
+    Enum.each(curve, fn {key, value} ->
+      if D.negative?(value) or D.gt?(value, @one) do
+        raise ArgumentError, "#{inspect(key)} must be in [0, 1], got #{value}"
+      end
+    end)
+
+    unless curve.deadzone |> D.add(curve.start_offset) |> D.lt?(@one) do
+      raise ArgumentError, ":deadzone + :start_offset must be below 1"
+    end
+
+    curve
+  end
+
+  @doc """
+  The output in [-1, 1] for a request in [-1, 1]. A linear request is
+  returned as is; a shaped one goes through all three steps.
+  """
+  def shape(requested, true = _linear, _curve), do: requested
+
+  def shape(requested, false, curve) do
+    requested
+    |> strip_deadzone(curve.deadzone)
+    |> blend(curve.expo)
+    |> offset(curve.start_offset)
+  end
+
+  # Zero within the dead zone; beyond it the remaining travel is
+  # stretched back over the full range, so full deflection still gives
+  # full output.
+  defp strip_deadzone(requested, deadzone) do
+    magnitude = D.abs(requested)
+
+    if D.lt?(magnitude, deadzone) or D.eq?(magnitude, deadzone) do
+      @zero
+    else
+      magnitude
+      |> D.sub(deadzone)
+      |> D.div(D.sub(@one, deadzone))
+      |> signed_as(requested)
+    end
+  end
+
+  # `(1 - expo) * x + expo * x * |x|`: the signed square keeps the sign
+  # and the endpoints while flattening the middle of the travel, and the
+  # blend sets how much of that flattening is applied.
+  defp blend(requested, expo) do
+    linear = requested |> D.mult(D.sub(@one, expo))
+    squared = requested |> D.abs() |> D.mult(requested) |> D.mult(expo)
+    D.add(linear, squared)
+  end
+
+  # Zero stays zero; anything else is remapped from [0, 1] onto
+  # [start_offset, 1] so the smallest non-zero output already reaches
+  # the ESC's edge of motion.
+  defp offset(requested, start_offset) do
+    if D.eq?(requested, @zero) do
+      @zero
+    else
+      requested
+      |> D.abs()
+      |> D.mult(D.sub(@one, start_offset))
+      |> D.add(start_offset)
+      |> signed_as(requested)
+    end
+  end
+
+  defp signed_as(magnitude, reference) do
+    if D.negative?(reference), do: D.negate(magnitude), else: magnitude
+  end
 end

--- a/vms/core/lib/vms_core/components/traxxas/throttle.ex
+++ b/vms/core/lib/vms_core/components/traxxas/throttle.ex
@@ -5,8 +5,9 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   ## From request to pulse
 
   A request in [-1, 1] goes through up to three steps before it becomes
-  a duty cycle. All three are tunable per vehicle; the defaults are no
-  dead zone, the full square and no start offset.
+  a duty cycle, and the result is capped. Everything is tunable per
+  vehicle; the defaults are no dead zone, the full square, no start
+  offset and no cap.
 
   1. **Dead zone** (`:deadzone`). A hand at rest is not exactly at
      centre: a trigger drifts by a few counts, a gamepad stick by a few
@@ -38,6 +39,23 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   follow it down rather than hold the edge of motion. `:linear_sources`
   lists the sources whose request is already a physical quantity: they
   skip all three steps.
+
+  ## The cap
+
+  `:max_throttle` is the output a full forward request produces, and
+  `:max_reverse` the same for a full negative one; both default to 1,
+  `:max_reverse` to `:max_throttle` when only that is given. The cap
+  *scales* rather than clips: full deflection still means "as fast as
+  allowed", so a hand's output runs over `[start_offset, max]` and a
+  physical quantity is multiplied by it. It applies to every source --
+  a vehicle that is too fast is too fast whoever is driving.
+
+  Two things follow. A commander that normalises a speed against the
+  vehicle's full-throttle speed must use the speed reached *at the cap*,
+  or it gets a fraction of what it asks for. And on a Traxxas ESC the
+  first pull into negative is proportional braking, so a reverse cap
+  below 1 also weakens the brake -- keep `:max_reverse` at 1 unless
+  reverse speed is the problem.
   """
   use GenServer
   alias Decimal, as: D
@@ -51,7 +69,13 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   @zero D.new(0)
   @one D.new(1)
 
-  @default_curve %{deadzone: @zero, expo: @one, start_offset: @zero}
+  @default_curve %{
+    deadzone: @zero,
+    expo: @one,
+    start_offset: @zero,
+    max_throttle: @one,
+    max_reverse: nil
+  }
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
@@ -170,10 +194,12 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   @doc """
   The curve parameters from a component's arguments, each defaulting to
   the value that leaves the request untouched. Fractions of full travel,
-  all in [0, 1]; `deadzone + start_offset` must stay below 1.
+  all in [0, 1]; `deadzone + start_offset` must stay below 1 and the
+  start offset must stay below both caps.
   """
   def curve(args) do
     curve = Map.merge(@default_curve, Map.take(args, Map.keys(@default_curve)))
+    curve = %{curve | max_reverse: curve.max_reverse || curve.max_throttle}
 
     Enum.each(curve, fn {key, value} ->
       if D.negative?(value) or D.gt?(value, @one) do
@@ -185,20 +211,32 @@ defmodule VmsCore.Components.Traxxas.Throttle do
       raise ArgumentError, ":deadzone + :start_offset must be below 1"
     end
 
+    unless D.lt?(curve.start_offset, curve.max_throttle) and
+             D.lt?(curve.start_offset, curve.max_reverse) do
+      raise ArgumentError, ":start_offset must be below :max_throttle and :max_reverse"
+    end
+
     curve
   end
 
   @doc """
   The output in [-1, 1] for a request in [-1, 1]. A linear request is
-  returned as is; a shaped one goes through all three steps.
+  only scaled by the cap; a shaped one goes through all three steps and
+  lands on `[start_offset, cap]`.
   """
-  def shape(requested, true = _linear, _curve), do: requested
+  def shape(requested, true = _linear, curve) do
+    requested |> D.abs() |> D.mult(cap(requested, curve)) |> signed_as(requested)
+  end
 
   def shape(requested, false, curve) do
     requested
     |> strip_deadzone(curve.deadzone)
     |> blend(curve.expo)
-    |> offset(curve.start_offset)
+    |> offset(curve.start_offset, cap(requested, curve))
+  end
+
+  defp cap(requested, curve) do
+    if D.negative?(requested), do: curve.max_reverse, else: curve.max_throttle
   end
 
   # Zero within the dead zone; beyond it the remaining travel is
@@ -227,15 +265,15 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   end
 
   # Zero stays zero; anything else is remapped from [0, 1] onto
-  # [start_offset, 1] so the smallest non-zero output already reaches
-  # the ESC's edge of motion.
-  defp offset(requested, start_offset) do
+  # [start_offset, cap] so the smallest non-zero output already reaches
+  # the ESC's edge of motion and full deflection stops at the cap.
+  defp offset(requested, start_offset, cap) do
     if D.eq?(requested, @zero) do
       @zero
     else
       requested
       |> D.abs()
-      |> D.mult(D.sub(@one, start_offset))
+      |> D.mult(D.sub(cap, start_offset))
       |> D.add(start_offset)
       |> signed_as(requested)
     end

--- a/vms/core/test/components/traxxas/source_switching_test.exs
+++ b/vms/core/test/components/traxxas/source_switching_test.exs
@@ -71,6 +71,7 @@ defmodule VmsCore.Components.Traxxas.SourceSwitchingTest do
         selected_control_level_source: @manager,
         requested_throttle_source: @commander,
         linear_sources: [],
+        curve: Throttle.curve(%{}),
         requested_throttle: D.new("0.6"),
         throttle: D.new(0)
       },
@@ -205,17 +206,85 @@ defmodule VmsCore.Components.Traxxas.SourceSwitchingTest do
              "the ESC stayed on the previous source's shaping"
     end
 
-    test "a joystick-shaped request is squared, keeping its sign" do
-      assert D.eq?(Throttle.shape(D.new("0.5"), false), D.new("0.25"))
-      assert D.eq?(Throttle.shape(D.new("-0.5"), false), D.new("-0.25"))
-      assert D.eq?(Throttle.shape(D.new("1"), false), D.new("1"))
+    test "with no curve configured a joystick request is squared, keeping its sign" do
+      curve = Throttle.curve(%{})
+      assert D.eq?(Throttle.shape(D.new("0.5"), false, curve), D.new("0.25"))
+      assert D.eq?(Throttle.shape(D.new("-0.5"), false, curve), D.new("-0.25"))
+      assert D.eq?(Throttle.shape(D.new("1"), false, curve), D.new("1"))
     end
 
     test "a physical quantity is applied as is" do
       # A planner asking for a fifth of full speed must get a fifth,
       # not a twenty-fifth.
-      assert D.eq?(Throttle.shape(D.new("0.2"), true), D.new("0.2"))
-      assert D.eq?(Throttle.shape(D.new("-0.2"), true), D.new("-0.2"))
+      curve = Throttle.curve(%{})
+      assert D.eq?(Throttle.shape(D.new("0.2"), true, curve), D.new("0.2"))
+      assert D.eq?(Throttle.shape(D.new("-0.2"), true, curve), D.new("-0.2"))
+    end
+
+    test "expo blends between linear and square" do
+      linear = Throttle.curve(%{expo: D.new(0)})
+      half = Throttle.curve(%{expo: D.new("0.5")})
+
+      assert D.eq?(Throttle.shape(D.new("0.5"), false, linear), D.new("0.5"))
+      # Half of 0.5 plus half of 0.25.
+      assert D.eq?(Throttle.shape(D.new("0.5"), false, half), D.new("0.375"))
+      assert D.eq?(Throttle.shape(D.new("-0.5"), false, half), D.new("-0.375"))
+      assert D.eq?(Throttle.shape(D.new("1"), false, half), D.new("1"))
+    end
+
+    test "the dead zone reads a drifting hand as zero and keeps full deflection" do
+      curve = Throttle.curve(%{deadzone: D.new("0.05"), expo: D.new(0)})
+
+      assert D.eq?(Throttle.shape(D.new("0.04"), false, curve), D.new(0))
+      assert D.eq?(Throttle.shape(D.new("-0.05"), false, curve), D.new(0))
+      assert D.eq?(Throttle.shape(D.new("1"), false, curve), D.new("1"))
+      assert D.eq?(Throttle.shape(D.new("-1"), false, curve), D.new("-1"))
+      # The remaining travel is stretched: 0.525 sits half way between
+      # 0.05 and 1, so it maps to 0.5.
+      assert D.eq?(Throttle.shape(D.new("0.525"), false, curve), D.new("0.5"))
+    end
+
+    test "the start offset lifts every non-zero output to the edge of motion" do
+      curve =
+        Throttle.curve(%{deadzone: D.new("0.05"), expo: D.new(0), start_offset: D.new("0.1")})
+
+      assert D.eq?(Throttle.shape(D.new(0), false, curve), D.new(0))
+
+      assert D.eq?(Throttle.shape(D.new("0.03"), false, curve), D.new(0)),
+             "a hand at rest must not creep the vehicle forward"
+
+      # The first request past the dead zone already sits at the offset.
+      first = Throttle.shape(D.new("0.06"), false, curve)
+      assert D.gt?(first, D.new("0.1")) and D.lt?(first, D.new("0.12"))
+
+      reverse = Throttle.shape(D.new("-0.06"), false, curve)
+      assert D.lt?(reverse, D.new("-0.1")) and D.gt?(reverse, D.new("-0.12"))
+
+      assert D.eq?(Throttle.shape(D.new("1"), false, curve), D.new("1"))
+      # 0.525 -> 0.5 after the dead zone -> 0.1 + 0.9 * 0.5.
+      assert D.eq?(Throttle.shape(D.new("0.525"), false, curve), D.new("0.55"))
+    end
+
+    test "a physical quantity skips the dead zone, the curve and the start offset" do
+      # A planner decelerating through a tiny velocity must be followed
+      # down, not held at the edge of motion until it publishes exactly
+      # zero.
+      curve =
+        Throttle.curve(%{deadzone: D.new("0.05"), expo: D.new(1), start_offset: D.new("0.1")})
+
+      assert D.eq?(Throttle.shape(D.new(0), true, curve), D.new(0))
+      assert D.eq?(Throttle.shape(D.new("0.02"), true, curve), D.new("0.02"))
+      assert D.eq?(Throttle.shape(D.new("-0.5"), true, curve), D.new("-0.5"))
+      assert D.eq?(Throttle.shape(D.new("1"), true, curve), D.new("1"))
+    end
+
+    test "the curve parameters are validated" do
+      assert_raise ArgumentError, fn -> Throttle.curve(%{expo: D.new("1.5")}) end
+      assert_raise ArgumentError, fn -> Throttle.curve(%{deadzone: D.new("-0.1")}) end
+
+      assert_raise ArgumentError, fn ->
+        Throttle.curve(%{deadzone: D.new("0.5"), start_offset: D.new("0.5")})
+      end
     end
   end
 end

--- a/vms/core/test/components/traxxas/source_switching_test.exs
+++ b/vms/core/test/components/traxxas/source_switching_test.exs
@@ -285,6 +285,56 @@ defmodule VmsCore.Components.Traxxas.SourceSwitchingTest do
       assert_raise ArgumentError, fn ->
         Throttle.curve(%{deadzone: D.new("0.5"), start_offset: D.new("0.5")})
       end
+
+      assert_raise ArgumentError, fn ->
+        Throttle.curve(%{start_offset: D.new("0.5"), max_throttle: D.new("0.5")})
+      end
+    end
+  end
+
+  describe "the cap" do
+    test "scales a hand's output onto [start_offset, max_throttle]" do
+      # Scaled, not clipped: full trigger still means "as fast as
+      # allowed", so the whole travel stays useful.
+      curve =
+        Throttle.curve(%{
+          deadzone: D.new("0.05"),
+          expo: D.new(0),
+          start_offset: D.new("0.1"),
+          max_throttle: D.new("0.5")
+        })
+
+      assert D.eq?(Throttle.shape(D.new("1"), false, curve), D.new("0.5"))
+      # 0.525 -> 0.5 after the dead zone -> 0.1 + 0.4 * 0.5.
+      assert D.eq?(Throttle.shape(D.new("0.525"), false, curve), D.new("0.3"))
+      assert D.eq?(Throttle.shape(D.new(0), false, curve), D.new(0))
+    end
+
+    test "scales a physical quantity without touching its shape" do
+      curve = Throttle.curve(%{max_throttle: D.new("0.5")})
+
+      assert D.eq?(Throttle.shape(D.new("1"), true, curve), D.new("0.5"))
+      assert D.eq?(Throttle.shape(D.new("0.2"), true, curve), D.new("0.1"))
+      assert D.eq?(Throttle.shape(D.new(0), true, curve), D.new(0))
+    end
+
+    test "reverse follows max_throttle unless given its own cap" do
+      same = Throttle.curve(%{max_throttle: D.new("0.5")})
+      assert D.eq?(Throttle.shape(D.new("-1"), true, same), D.new("-0.5"))
+      assert D.eq?(Throttle.shape(D.new("-1"), false, same), D.new("-0.5"))
+
+      # Braking lives on the negative side of a Traxxas ESC, so a vehicle
+      # can cap forward speed and keep the full brake.
+      braking = Throttle.curve(%{max_throttle: D.new("0.5"), max_reverse: D.new(1)})
+      assert D.eq?(Throttle.shape(D.new("-1"), false, braking), D.new("-1"))
+      assert D.eq?(Throttle.shape(D.new("-1"), true, braking), D.new("-1"))
+      assert D.eq?(Throttle.shape(D.new("1"), false, braking), D.new("0.5"))
+    end
+
+    test "no cap leaves the output untouched" do
+      curve = Throttle.curve(%{})
+      assert D.eq?(Throttle.shape(D.new("1"), false, curve), D.new("1"))
+      assert D.eq?(Throttle.shape(D.new("-1"), true, curve), D.new("-1"))
     end
   end
 end


### PR DESCRIPTION
## Problem

On the OVCS Mini the throttle feels like it has a wide dead band and then starts abruptly, from both the radio trigger and the ROS joystick.

`Traxxas.Throttle` squared every hand request before writing the duty cycle. The square itself has no dead band, but the ESC and motor need a minimum pulse before the wheels turn, and squaring pushes that threshold far along the trigger. Wheels that start at 10% throttle need 32% of the travel, and the slope past that point is already 0.6.

| Wheels first move at | Trigger travel needed |
|---|---|
| 10% | ~32% |
| 15% | ~39% |
| 20% | ~45% |

PWM resolution and CAN encoding were ruled out: the hat resolves about 1.6 µs over the 1000–2000 µs pulse, and the ROS throttle signal has 0.001 resolution.

## Change

A hand request now goes through three per-vehicle steps, each documented in the moduledoc:

1. **Dead zone** — requests within it read as zero, the remaining travel is stretched back to full range. Required so the start offset cannot turn a drifting trigger into a creeping vehicle.
2. **Feel curve** — a blend between linear and the signed square (`expo` 0 to 1).
3. **Start offset** — every non-zero output is remapped onto `[start_offset, 1]`, so the first perceptible input already sits at the edge of motion.

Sources listed in `linear_sources` skip all three, so the planner's velocity command is applied exactly as before.

The module defaults reproduce the previous behaviour (no dead zone, full square, no offset). The Mini composer sets a 5% dead zone (matches the trigger drift, the joy node's dead zone and the radio braking threshold), a half blend, and a 6% start offset.

## Tuning the start offset

The 6% is an estimate. On the firmware currently on the car, ease the trigger and read the requested throttle on the radio control page at the moment the wheels first move; its square is the output the ESC needed and is the value for `@throttle_start_offset`. Too high makes the first touch a jump, too low wastes a little travel.

## Before the first drive with this build

- Confirm channel 2 rests within 1475–1525 on the radio control page. A trim beyond the dead zone now lands at 6% throttle instead of nothing.
- A trigger hovering exactly on the dead zone edge flicks between neutral and 6%. Inherent to dead-band compensation, harmless.

## Verification

- `mix test --no-start` in `vms/core`: 125 tests, 0 failures, including new cases for each step and their validation.
- `mix compile --warnings-as-errors` clean for `vms_core` and `ovcs_mini`.
- Not yet driven on the car.
