### PR TITLE
Cap the Traxxas throttle per vehicle

### DIFF
--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -22,16 +22,24 @@ defmodule OvcsMini.Vms.Composer do
   def default_can_mapping(:host), do: "ovcs:vcan0"
   def default_can_mapping(:target), do: "ovcs:spi0.0"
 
-  # Full throttle in m/s. Not geometry — a property of the motor and
-  # gearing, not a measured dimension of the chassis. ESTIMATE: a stock
-  # Slash 4x4 does roughly 30 mph, and the simulated model is capped at
-  # 13 m/s, but nothing has measured this one under load.
-  @max_speed_m_s 5.0
+  # Speed in m/s at the throttle cap below, which is what a full request
+  # from the planner produces. Not geometry — a property of the motor,
+  # the gearing and the cap, not a measured dimension of the chassis.
+  # ESTIMATE: a stock Slash 4x4 does roughly 30 mph and the simulated
+  # model is capped at 13 m/s; the uncapped truck was estimated at
+  # 5 m/s and this is half of it, but nothing has measured this one
+  # under load.
+  @max_speed_m_s 2.5
 
   # Throttle feel, see `Traxxas.Throttle` for what each one does.
   @throttle_deadzone Decimal.new("0.05")
   @throttle_expo Decimal.new("0.5")
   @throttle_start_offset Decimal.new("0.06")
+  # Half the pulse range forward. The uncapped truck is far too fast for
+  # where it drives; the reverse side stays at 1 because on this ESC the
+  # first pull into negative is the brake.
+  @throttle_max Decimal.new("0.5")
+  @throttle_max_reverse Decimal.new("1")
 
   # The trigger magnet sits in the spur gear, so wheel speed needs the
   # ratio from the spur gear to the wheels: the Slash 4x4 transmission's
@@ -185,7 +193,8 @@ defmodule OvcsMini.Vms.Composer do
          selected_control_level_source: Managers.ControlLevel,
          # A velocity is a physical quantity, not a hand on a trigger:
          # it bypasses the dead zone, the feel curve and the start
-         # offset below.
+         # offset below, and only gets the cap. `@max_speed_m_s` is the
+         # speed at that cap for that reason.
          linear_sources: [OVCS.RosVelocityCommand],
          # The trigger at rest drifts by up to 20 counts of 500, and
          # the joystick node's own dead zone is the same 5%. Matches
@@ -202,7 +211,9 @@ defmodule OvcsMini.Vms.Composer do
          # force when it was taken. Too low only wastes a little
          # travel; too high makes the first touch a jump, so it starts
          # conservative.
-         start_offset: @throttle_start_offset
+         start_offset: @throttle_start_offset,
+         max_throttle: @throttle_max,
+         max_reverse: @throttle_max_reverse
        }},
       {OVCS.PulseSpeedSensor,
        %{

--- a/vms/core/lib/vms_core/components/traxxas/throttle.ex
+++ b/vms/core/lib/vms_core/components/traxxas/throttle.ex
@@ -5,8 +5,9 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   ## From request to pulse
 
   A request in [-1, 1] goes through up to three steps before it becomes
-  a duty cycle. All three are tunable per vehicle; the defaults are no
-  dead zone, the full square and no start offset.
+  a duty cycle, and the result is capped. Everything is tunable per
+  vehicle; the defaults are no dead zone, the full square, no start
+  offset and no cap.
 
   1. **Dead zone** (`:deadzone`). A hand at rest is not exactly at
      centre: a trigger drifts by a few counts, a gamepad stick by a few
@@ -38,6 +39,23 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   follow it down rather than hold the edge of motion. `:linear_sources`
   lists the sources whose request is already a physical quantity: they
   skip all three steps.
+
+  ## The cap
+
+  `:max_throttle` is the output a full forward request produces, and
+  `:max_reverse` the same for a full negative one; both default to 1,
+  `:max_reverse` to `:max_throttle` when only that is given. The cap
+  *scales* rather than clips: full deflection still means "as fast as
+  allowed", so a hand's output runs over `[start_offset, max]` and a
+  physical quantity is multiplied by it. It applies to every source --
+  a vehicle that is too fast is too fast whoever is driving.
+
+  Two things follow. A commander that normalises a speed against the
+  vehicle's full-throttle speed must use the speed reached *at the cap*,
+  or it gets a fraction of what it asks for. And on a Traxxas ESC the
+  first pull into negative is proportional braking, so a reverse cap
+  below 1 also weakens the brake -- keep `:max_reverse` at 1 unless
+  reverse speed is the problem.
   """
   use GenServer
   alias Decimal, as: D
@@ -51,7 +69,13 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   @zero D.new(0)
   @one D.new(1)
 
-  @default_curve %{deadzone: @zero, expo: @one, start_offset: @zero}
+  @default_curve %{
+    deadzone: @zero,
+    expo: @one,
+    start_offset: @zero,
+    max_throttle: @one,
+    max_reverse: nil
+  }
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
@@ -170,10 +194,12 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   @doc """
   The curve parameters from a component's arguments, each defaulting to
   the value that leaves the request untouched. Fractions of full travel,
-  all in [0, 1]; `deadzone + start_offset` must stay below 1.
+  all in [0, 1]; `deadzone + start_offset` must stay below 1 and the
+  start offset must stay below both caps.
   """
   def curve(args) do
     curve = Map.merge(@default_curve, Map.take(args, Map.keys(@default_curve)))
+    curve = %{curve | max_reverse: curve.max_reverse || curve.max_throttle}
 
     Enum.each(curve, fn {key, value} ->
       if D.negative?(value) or D.gt?(value, @one) do
@@ -185,20 +211,32 @@ defmodule VmsCore.Components.Traxxas.Throttle do
       raise ArgumentError, ":deadzone + :start_offset must be below 1"
     end
 
+    unless D.lt?(curve.start_offset, curve.max_throttle) and
+             D.lt?(curve.start_offset, curve.max_reverse) do
+      raise ArgumentError, ":start_offset must be below :max_throttle and :max_reverse"
+    end
+
     curve
   end
 
   @doc """
   The output in [-1, 1] for a request in [-1, 1]. A linear request is
-  returned as is; a shaped one goes through all three steps.
+  only scaled by the cap; a shaped one goes through all three steps and
+  lands on `[start_offset, cap]`.
   """
-  def shape(requested, true = _linear, _curve), do: requested
+  def shape(requested, true = _linear, curve) do
+    requested |> D.abs() |> D.mult(cap(requested, curve)) |> signed_as(requested)
+  end
 
   def shape(requested, false, curve) do
     requested
     |> strip_deadzone(curve.deadzone)
     |> blend(curve.expo)
-    |> offset(curve.start_offset)
+    |> offset(curve.start_offset, cap(requested, curve))
+  end
+
+  defp cap(requested, curve) do
+    if D.negative?(requested), do: curve.max_reverse, else: curve.max_throttle
   end
 
   # Zero within the dead zone; beyond it the remaining travel is
@@ -227,15 +265,15 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   end
 
   # Zero stays zero; anything else is remapped from [0, 1] onto
-  # [start_offset, 1] so the smallest non-zero output already reaches
-  # the ESC's edge of motion.
-  defp offset(requested, start_offset) do
+  # [start_offset, cap] so the smallest non-zero output already reaches
+  # the ESC's edge of motion and full deflection stops at the cap.
+  defp offset(requested, start_offset, cap) do
     if D.eq?(requested, @zero) do
       @zero
     else
       requested
       |> D.abs()
-      |> D.mult(D.sub(@one, start_offset))
+      |> D.mult(D.sub(cap, start_offset))
       |> D.add(start_offset)
       |> signed_as(requested)
     end

--- a/vms/core/test/components/traxxas/source_switching_test.exs
+++ b/vms/core/test/components/traxxas/source_switching_test.exs
@@ -285,6 +285,56 @@ defmodule VmsCore.Components.Traxxas.SourceSwitchingTest do
       assert_raise ArgumentError, fn ->
         Throttle.curve(%{deadzone: D.new("0.5"), start_offset: D.new("0.5")})
       end
+
+      assert_raise ArgumentError, fn ->
+        Throttle.curve(%{start_offset: D.new("0.5"), max_throttle: D.new("0.5")})
+      end
+    end
+  end
+
+  describe "the cap" do
+    test "scales a hand's output onto [start_offset, max_throttle]" do
+      # Scaled, not clipped: full trigger still means "as fast as
+      # allowed", so the whole travel stays useful.
+      curve =
+        Throttle.curve(%{
+          deadzone: D.new("0.05"),
+          expo: D.new(0),
+          start_offset: D.new("0.1"),
+          max_throttle: D.new("0.5")
+        })
+
+      assert D.eq?(Throttle.shape(D.new("1"), false, curve), D.new("0.5"))
+      # 0.525 -> 0.5 after the dead zone -> 0.1 + 0.4 * 0.5.
+      assert D.eq?(Throttle.shape(D.new("0.525"), false, curve), D.new("0.3"))
+      assert D.eq?(Throttle.shape(D.new(0), false, curve), D.new(0))
+    end
+
+    test "scales a physical quantity without touching its shape" do
+      curve = Throttle.curve(%{max_throttle: D.new("0.5")})
+
+      assert D.eq?(Throttle.shape(D.new("1"), true, curve), D.new("0.5"))
+      assert D.eq?(Throttle.shape(D.new("0.2"), true, curve), D.new("0.1"))
+      assert D.eq?(Throttle.shape(D.new(0), true, curve), D.new(0))
+    end
+
+    test "reverse follows max_throttle unless given its own cap" do
+      same = Throttle.curve(%{max_throttle: D.new("0.5")})
+      assert D.eq?(Throttle.shape(D.new("-1"), true, same), D.new("-0.5"))
+      assert D.eq?(Throttle.shape(D.new("-1"), false, same), D.new("-0.5"))
+
+      # Braking lives on the negative side of a Traxxas ESC, so a vehicle
+      # can cap forward speed and keep the full brake.
+      braking = Throttle.curve(%{max_throttle: D.new("0.5"), max_reverse: D.new(1)})
+      assert D.eq?(Throttle.shape(D.new("-1"), false, braking), D.new("-1"))
+      assert D.eq?(Throttle.shape(D.new("-1"), true, braking), D.new("-1"))
+      assert D.eq?(Throttle.shape(D.new("1"), false, braking), D.new("0.5"))
+    end
+
+    test "no cap leaves the output untouched" do
+      curve = Throttle.curve(%{})
+      assert D.eq?(Throttle.shape(D.new("1"), false, curve), D.new("1"))
+      assert D.eq?(Throttle.shape(D.new("-1"), true, curve), D.new("-1"))
     end
   end
 end


### PR DESCRIPTION
Stacked on #70. Merge that one first; this PR then retargets to `main`.

## Problem

The Mini at full pulse is far faster than anywhere it drives, whether the radio trigger, the joystick or the planner is commanding it.

## Change

`Traxxas.Throttle` takes two new curve parameters, both fractions of the pulse range and both defaulting to 1:

- `max_throttle` — what a full forward request produces.
- `max_reverse` — the same for a full negative request; defaults to `max_throttle` when only that is given.

The cap **scales rather than clips**. A hand's output runs over `[start_offset, cap]` and a linear source is multiplied by the cap, so full deflection still means "as fast as allowed" and no trigger travel is wasted. It sits in the actuator because every commander ends there.

Reverse gets its own cap because on a Traxxas ESC the first pull into negative is proportional braking; a symmetric cap would also weaken the brake.

## Mini settings

| Parameter | Value | Pulse at full request |
|---|---|---|
| `max_throttle` | 0.5 | 1750 µs |
| `max_reverse` | 1 | 1000 µs (full brake / full reverse) |

The planner normalises velocity against the speed a full request produces, which is now the speed **at the cap**. `@max_speed_m_s` drops from 5 to 2.5 so a velocity command maps to the same pulse as before this change. Both numbers remain estimates until measured with the pulse speed sensor.

## Verification

- `mix test --no-start` in `vms/core`: 129 tests, 0 failures, with new cases for scaling, the reverse cap and the validation that `start_offset` stays below both caps.
- `mix compile --warnings-as-errors` clean for `vms_core` and `ovcs_mini`.
- Not yet driven on the car.
