### PR TITLE
fix(compute): keep NAT off frames bridged between eth0 and the AP

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -8,7 +8,7 @@ vehicle, or does it never leave a workstation?**
 compose/
 ├── compute/          PUSHED TO BALENA — the vehicle's compute node, one deployable unit
 │   ├── docker-compose.yml    the on-vehicle stack (name and place imposed by balena)
-│   ├── images/               every image the car runs: ros2/, nav2/, wifi-firmware/
+│   ├── images/               every image the car runs: ros2/, nav2/, wifi-firmware/, bridge-nat-fix/
 │   ├── nav2/                 Nav2 launch + parameters — baked on the car, mounted by the simulator
 │   └── host/                 balenaOS network config (copied to the device once, never pushed)
 └── local/            NEVER PUSHED — the operator's machine and the simulation workstation
@@ -38,6 +38,7 @@ multicast, just TCP peerings to `zenohd`.
 | `foxglove_bridge` | compute | Studio attaches over the LAN to `ws://<compute-node-ip>:8765` |
 | `nav2` | compute | the planner survives the base station leaving, like the router |
 | `wifi_firmware` | compute | AX210 blobs for the host kernel — not ROS at all |
+| `bridge_nat_fix` | compute | one nat rule so mDNS crosses the vehicle bridge — not ROS either |
 | `ros2` (tooling shell) | local/base | interactive, `docker compose exec` |
 | `joy` | local/base | the game controller is with the operator, not the car |
 | `calibrator` | local/base | one-shot X11 GUI |

--- a/compose/compute/README.md
+++ b/compose/compute/README.md
@@ -12,12 +12,13 @@ either.
 
 ```
 compute/
-├── docker-compose.yml    the stack: wifi_firmware, zenohd, foxglove_bridge, nav2
+├── docker-compose.yml    the stack: wifi_firmware, bridge_nat_fix, zenohd, foxglove_bridge, nav2
 ├── .dockerignore         keeps host/ and this file out of the pushed tarball
 ├── images/
 │   ├── ros2/             the shared ROS 2 image: entrypoint, Zenoh template, launchers
 │   ├── nav2/             the Nav2 image (Dockerfile only; it COPYs ../ros2 and ../../nav2)
-│   └── wifi-firmware/    AX210 firmware staged into balenaOS's extra-firmware volume
+│   ├── wifi-firmware/    AX210 firmware staged into balenaOS's extra-firmware volume
+│   └── bridge-nat-fix/   keeps the host's NAT off frames bridged between eth0 and the AP
 ├── nav2/
 │   ├── launch/           baked into images/nav2 here, bind-mounted by ../local/simulation.yml
 │   └── config/           nav2.yaml and the Ackermann behaviour trees
@@ -48,7 +49,8 @@ docker compose up -d zenohd foxglove_bridge nav2
 Name the services: `wifi_firmware` copies its blobs into
 `/extra-firmware`, a volume only balenaOS mounts (through the
 `io.balena.features.extra-firmware` label), so on a workstation the
-copy fails and the container restarts forever. Do not run this beside
+copy fails and the container restarts forever, and `bridge_nat_fix`
+would edit the workstation's nat table. Do not run this beside
 `../local/base.yml --profile standalone` — both start a router on
 port 7447. And note what this rehearsal is not: Nav2 here runs
 always-on against the wall clock with the router at `127.0.0.1`, the

--- a/compose/compute/docker-compose.yml
+++ b/compose/compute/docker-compose.yml
@@ -59,6 +59,18 @@ services:
     # `always` default and the container simply never exits (see
     # ./images/wifi-firmware/Dockerfile).
 
+  bridge_nat_fix:
+    # Keeps the host's NAT off frames the ovcs0 bridge forwards between
+    # eth0 and the access point — without it mDNS between a laptop on
+    # the access point and the wired boards is silently broken. See
+    # ./images/bridge-nat-fix/Dockerfile for the mechanism. Privileged
+    # host networking because it edits the host's nat table; it loops
+    # so the rule outlives NetworkManager re-activating the bridge.
+    build: ./images/bridge-nat-fix
+    restart: always
+    network_mode: host
+    privileged: true
+
   zenohd:
     # The vehicle *is* the router for the OVCS fabric, so the fabric
     # survives the base station disconnecting. Everything else —

--- a/compose/compute/images/bridge-nat-fix/Dockerfile
+++ b/compose/compute/images/bridge-nat-fix/Dockerfile
@@ -1,0 +1,30 @@
+# Keeps NetworkManager's NAT off traffic that never leaves the vehicle
+# bridge. See ../../host/README.md for the network this belongs to.
+#
+# balena-engine turns on `net.bridge.bridge-nf-call-iptables`, so every
+# frame the ovcs0 bridge forwards between eth0 and the access point is
+# run through iptables as if it were routed. The `method=shared` bridge
+# carries a MASQUERADE rule for anything not addressed to 10.42.0.0/24,
+# and a multicast destination (224.0.0.251 for mDNS, 255.255.255.255 for
+# a DHCP broadcast) is exactly that: a laptop's mDNS query leaves eth0
+# with the bridge's own address and a random source port, a board
+# answers it as a legacy unicast query, and the laptop's resolver — as
+# RFC 6762 requires — discards a reply that did not come from port 5353.
+# The result is `ovcs-mini-vms.local` resolving from the site Wi-Fi but
+# not from the vehicle's own access point.
+#
+# The per-bridge `nf_call_iptables` knob cannot switch this off while the
+# global sysctl is on, and turning the global one off would change how
+# the engine isolates its own container networks. So the fix is one NAT
+# rule, ahead of NetworkManager's: what leaves through ovcs0 stays as it
+# is. iptables-legacy because the host's iptables is the legacy backend
+# (`iptables -V` on the host) and both must edit the same tables.
+FROM alpine:3.22
+
+# iptables-legacy is the binary; the match extensions it loads (the
+# `comment` match the rule is tagged with) ship in the iptables package.
+RUN apk add --no-cache iptables iptables-legacy
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/compose/compute/images/bridge-nat-fix/entrypoint.sh
+++ b/compose/compute/images/bridge-nat-fix/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Ensure the rule is present, then keep it present: NetworkManager
+# rewrites its own nat rules whenever the shared connection is
+# re-activated, and a reboot starts from nothing. Checking every 30 s
+# with -C is free; the rule is only ever inserted when missing.
+set -eu
+
+BRIDGE="${BRIDGE_IFACE:-ovcs0}"
+RULE="POSTROUTING -o $BRIDGE -m comment --comment ovcs-bridge-no-nat -j ACCEPT"
+
+while :; do
+  if ! iptables-legacy -t nat -C $RULE 2>/dev/null; then
+    if iptables-legacy -t nat -I $RULE 2>/dev/null; then
+      echo "inserted: traffic leaving through $BRIDGE is exempt from NAT"
+    else
+      echo "cannot edit the nat table; not privileged, or $BRIDGE does not exist yet"
+    fi
+  fi
+  sleep 30
+done

--- a/docs/ros_compute_node.md
+++ b/docs/ros_compute_node.md
@@ -209,6 +209,22 @@ installs the NAT rule unconditionally; if `wlan0` is unassociated,
 clients still get leases and full vehicle-local connectivity and simply
 have no route off the car.
 
+One piece of the vehicle network is not a keyfile but a container:
+`bridge_nat_fix` in
+[`compose/compute/docker-compose.yml`](../compose/compute/docker-compose.yml).
+balena-engine switches `bridge-nf-call-iptables` on, so frames `ovcs0`
+forwards between `eth0` and the access point traverse iptables, where
+`method=shared`'s MASQUERADE rewrites anything not addressed to
+`10.42.0.0/24` — multicast included. A laptop's mDNS query then reaches
+the wire from the bridge's address on a random port, the board answers
+it as a legacy unicast query, and the laptop's resolver discards the
+reply for not coming from port 5353. `ovcs-mini-vms.local` works from
+the site Wi-Fi and fails from the vehicle's own access point, with
+nothing in any log. The container inserts one rule ahead of
+NetworkManager's — traffic leaving through `ovcs0` is not translated —
+and re-asserts it every 30 s, since NetworkManager rewrites its nat
+rules whenever the connection is re-activated.
+
 Keyfile templates live in
 [`compose/compute/host/system-connections/`](../compose/compute/host/system-connections/).
 Two non-obvious constraints are baked into them, and the comments in
@@ -390,11 +406,12 @@ iw dev wlP1p1s0 info                 # type AP, expected channel
 ip -4 addr show ovcs0                # 10.42.0.1/24
 ls /sys/class/net/ovcs0/brif/        # eth0 wlP1p1s0
 cat /var/lib/NetworkManager/dnsmasq-ovcs0.leases   # one line per board
+iptables -t nat -S POSTROUTING | head -2           # ovcs-bridge-no-nat before nm-shared-ovcs0
 ip route | grep default              # exactly one, via wlan0
 journalctl -k -b | grep iwlwifi      # "loaded firmware" and "loaded PNVM"
 
-# From a laptop on the site Wi-Fi
-ping ovcs-mini-vms.local             # each board, at its site address
+# From a laptop on the site Wi-Fi, then again on the access point
+ping ovcs-mini-vms.local             # site address, then 10.42.0.x
 ```
 
 That last kernel line is the check worth keeping: if the boot-time


### PR DESCRIPTION
## Symptom

From a laptop on the vehicle's access point, `ovcs-mini-vms.local` (and every other board) does not resolve; the same names resolve from the site Wi-Fi, and the boards answer by IP from the access point. Nothing in any log.

## Cause

balena-engine sets `net.bridge.bridge-nf-call-iptables=1`, so frames the `ovcs0` bridge forwards between `eth0` and `wlP1p1s0` traverse iptables. NetworkManager's `method=shared` installs `-s 10.42.0.0/24 ! -d 10.42.0.0/24 -j MASQUERADE`, which matches a multicast destination. Captured on the car: the laptop's query to `224.0.0.251:5353` leaves `eth0` as `10.42.0.1:<random>`, the board (mdns_lite) treats it as a legacy unicast query and answers unicast, and the laptop's avahi drops a reply not sourced from port 5353 (RFC 6762 §6). The per-bridge `nf_call_iptables` cannot disable the traversal while the global sysctl is on, and the global one is the engine's.

## Fix

One nat rule ahead of NetworkManager's: `-t nat -I POSTROUTING -o ovcs0 -m comment --comment ovcs-bridge-no-nat -j ACCEPT`. Inserted by hand on the Mini it fixed resolution as soon as the stale conntrack entry expired (avahi, `getent`, the dashboard URL, all three boards). The new `bridge_nat_fix` service (Alpine, `iptables-legacy` to match the host's backend, privileged host networking) inserts it when missing and re-checks every 30 s, since NetworkManager rewrites its nat rules on re-activation and a reboot starts from nothing.

Verified on the device that Alpine's `iptables-legacy` inside a privileged host-network container sees and edits the host's table (the `iptables` package is needed alongside for the `comment` match extension).

Documented in `docs/ros_compute_node.md` (Networking and Checks) and the compose READMEs.
