### PR TITLE
fix(ovcs_mini): cap the throttle at a tenth forward, a fifth in reverse

### DIFF
--- a/controllers/generic_controller/lib/Controller/Controller.cpp
+++ b/controllers/generic_controller/lib/Controller/Controller.cpp
@@ -79,12 +79,8 @@ void Controller::shutdownAllOtherPins(){
 void Controller::setExternalPwm() {
   ExternalPwm externalPwmRequest = _can.parseExternalPwmRequest();
   ExternalPwm& externalPwm = _configuration._externalPwms[externalPwmRequest.pwmId()];
-  // The VMS retransmits every request frame on a 10 ms timer whether
-  // or not anything changed, and the hat parses each serial packet
-  // inside its UART receive interrupt with floating-point math. An
-  // identical packet is pure load there: it can delay the next channel's
-  // packet past the hardware FIFO and lose it. Relay changes at once
-  // and unchanged settings only at the slow refresh rate.
+  // The VMS repeats frames every 10 ms. Relay changes immediately;
+  // refresh unchanged settings less often to keep UART traffic low.
   unsigned long now = millis();
   if (externalPwm.needsRelay(externalPwmRequest, now)) {
     externalPwm.update(externalPwmRequest, now);

--- a/docs/testing_generic_controllers.md
+++ b/docs/testing_generic_controllers.md
@@ -85,6 +85,63 @@ stopping.
 The frame layouts are in
 [`controllers/generic_controller/README.md`](../controllers/generic_controller/README.md).
 
+## OVCS Mini throttle resolution and calibration
+
+The throttle path is radio channel 2 on CAN `0x2A0`, VMS
+`Traxxas.Throttle`, CAN `0x706`, Arduino UART, then HAT output 1 (RB3)
+to the ESC. The Arduino forwards the 16-bit duty unchanged. Full scale
+is 65535 on both ends, and the output frequency is 100 Hz.
+
+Use the HAT firmware with per-output prescaler selection and nearest-tick
+rounding. At 100 Hz it uses a /10 prescaler at 64 MHz: 64000 timer ticks
+per period, or 0.15625 us per tick. A fixed /100 prescaler leaves only
+about 27 distinct pulses in the Mini's 1510-1550 us forward modulation
+range. Updating only the VMS does not fix that hardware quantisation.
+
+The Mini composer sets 5% input deadzone, 0.5 expo, 0.02 start offset,
+0.1 forward cap and 0.2 reverse/brake cap. For forward requests outside
+the deadzone:
+
+```text
+request = (radio_channel_2 - 1500) / 500
+x = (request - 0.05) / 0.95
+throttle = 0.02 + 0.08 * (0.5*x + 0.5*x*x)
+pulse_us = 1500 + 500*throttle
+```
+
+The **Radio Control** page shows both the input request and the commanded
+throttle/pulse after the curve. The latter is before CAN/timer quantisation,
+not a measured HAT or ESC readback. The first VMS tick commands neutral,
+even if no source has been selected yet.
+
+After deploying the VMS and flashing the HAT, verify the pulse on RB3 with
+the ESC disconnected from the signal. A period is 10 ms; expected widths
+are 1500 us at neutral, approximately 1510 us just beyond the forward
+deadzone, 1525 us at request 0.525, 1550 us at full forward and 1400 us
+at full reverse/brake. Allow for oscillator accuracy and sub-microsecond
+CAN/timer rounding. Check the steering output too after flashing the HAT.
+
+With the drivetrain secured and wheels clear, reconnect the ESC and sweep
+the trigger slowly up and down. Record **Commanded ESC Pulse** when the
+wheels start and when they stop; repeat under a controlled rolling load.
+The start threshold can differ from the stop threshold. The initial offset
+is conservative, not a measured calibration. A measured forward threshold
+can be expressed as `(pulse_us - 1500) / 500`, but do not raise the offset
+above the minimum sustainable command merely to force a quicker start:
+that creates a jump and spends the available modulation range.
+
+Check which endpoints the ESC learned. Its calibration must use the full
+1000/1500/2000 us actuator range, following the exact ESC model's procedure,
+with propulsion mechanically isolated. Do not calibrate it using the
+normal capped Mini curve: teaching 1550 us as full forward defeats the cap.
+Return to normal capped operation before any driving test.
+
+The speed sensor is available for observing the result, but the throttle
+path is open loop: a 10% throttle cap is not a 10% speed guarantee. If the
+lowest stable motor speed is still too high after the waveform and ESC
+calibration are verified, further changes need measured drivetrain behavior;
+an uncalibrated speed controller or a larger start offset is not a substitute.
+
 ## Troubleshooting
 
 ### Controller stays in `ADOPTION_REQUIRED`

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -35,7 +35,11 @@ defmodule OvcsMini.Vms.Composer do
   # Throttle feel, see `Traxxas.Throttle` for what each one does.
   @throttle_deadzone Decimal.new("0.05")
   @throttle_expo Decimal.new("0.5")
-  @throttle_start_offset Decimal.new("0.06")
+  # A 10 us start offset leaves 40 us of forward modulation before the
+  # 1550 us cap. Keep this conservative until the ESC's start/stop
+  # thresholds have been measured under load; the Radio Control page
+  # exposes the commanded pulse width, before HAT timer quantisation.
+  @throttle_start_offset Decimal.new("0.02")
   # A tenth of the pulse range forward (1550 µs at full trigger), with
   # the ESC calibrated against this actuator's full 1000-2000 µs range.
   # Half the range was far too fast for where the truck drives and a

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -27,19 +27,23 @@ defmodule OvcsMini.Vms.Composer do
   # the gearing and the cap, not a measured dimension of the chassis.
   # ESTIMATE: a stock Slash 4x4 does roughly 30 mph and the simulated
   # model is capped at 13 m/s; the uncapped truck was estimated at
-  # 5 m/s and this is half of it, but nothing has measured this one
-  # under load.
-  @max_speed_m_s 2.5
+  # 5 m/s and a tenth of the pulse range is taken as a tenth of that,
+  # though an ESC is not linear and nothing has measured this one under
+  # load. The pulse speed sensor below is what to measure it with.
+  @max_speed_m_s 0.5
 
   # Throttle feel, see `Traxxas.Throttle` for what each one does.
   @throttle_deadzone Decimal.new("0.05")
   @throttle_expo Decimal.new("0.5")
   @throttle_start_offset Decimal.new("0.06")
-  # Half the pulse range forward. The uncapped truck is far too fast for
-  # where it drives; the reverse side stays at 1 because on this ESC the
-  # first pull into negative is the brake.
-  @throttle_max Decimal.new("0.5")
-  @throttle_max_reverse Decimal.new("1")
+  # A tenth of the pulse range forward (1550 µs at full trigger), with
+  # the ESC calibrated against this actuator's full 1000-2000 µs range.
+  # Half the range was far too fast for where the truck drives and a
+  # fifth still was. Reverse is capped too, a little higher: on this
+  # ESC the first pull into negative is the brake, so this is also the
+  # braking force, and at these speeds a fifth of it stops the truck.
+  @throttle_max Decimal.new("0.1")
+  @throttle_max_reverse Decimal.new("0.2")
 
   # The trigger magnet sits in the spur gear, so wheel speed needs the
   # ratio from the spur gear to the wheels: the Slash 4x4 transmission's

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/radio_control_page.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer/dashboard/radio_control_page.ex
@@ -1,5 +1,6 @@
 defmodule OvcsMini.Vms.Composer.Dashboard.RadioControlPage do
   alias VmsCore.Components.OVCS.RadioControl
+  alias VmsCore.Components.Traxxas.Throttle
   alias OvcsMini.Vms.Composer.Dashboard.Blocks.RadioControlThrottleAndSteeringBlock
 
   def definition(order: order) do
@@ -42,6 +43,19 @@ defmodule OvcsMini.Vms.Composer.Dashboard.RadioControlPage do
               name: "Requested Throttle",
               module: RadioControl.Throttle,
               key: :requested_throttle
+            },
+            %{
+              type: :metric,
+              name: "Commanded Throttle (after curve)",
+              module: Throttle,
+              key: :throttle
+            },
+            %{
+              type: :metric,
+              name: "Commanded ESC Pulse",
+              module: Throttle,
+              key: :pulse_width_us,
+              unit: "µs"
             }
           ]
         },

--- a/vms/core/lib/vms_core/components/traxxas/throttle.ex
+++ b/vms/core/lib/vms_core/components/traxxas/throttle.ex
@@ -64,8 +64,9 @@ defmodule VmsCore.Components.Traxxas.Throttle do
 
   @loop_period 10
   @pwm_frequency 100
-  @neutral_duty_cycle_percentage D.new("0.15")
-  @duty_cycle_percentage_range D.new("0.05")
+  @neutral_pulse_width_us D.new(1500)
+  @pulse_width_range_us D.new(500)
+  @pwm_period_us D.new(div(1_000_000, @pwm_frequency))
   @zero D.new(0)
   @one D.new(1)
 
@@ -105,7 +106,9 @@ defmodule VmsCore.Components.Traxxas.Throttle do
        # first tick.
        requested_throttle_source: nil,
        requested_throttle: @zero,
-       throttle: @zero
+       # No pulse has been sent yet: even a zero first request must
+       # enable the ESC signal and establish neutral.
+       throttle: nil
      }}
   end
 
@@ -168,15 +171,17 @@ defmodule VmsCore.Components.Traxxas.Throttle do
         state.curve
       )
 
-    case D.eq?(state.throttle, throttle) do
+    case not is_nil(state.throttle) and D.eq?(state.throttle, throttle) do
       true ->
         state
 
       false ->
-        duty_cycle_percentage =
+        pulse_width_us =
           throttle
-          |> D.mult(@duty_cycle_percentage_range)
-          |> D.add(@neutral_duty_cycle_percentage)
+          |> D.mult(@pulse_width_range_us)
+          |> D.add(@neutral_pulse_width_us)
+
+        duty_cycle_percentage = D.div(pulse_width_us, @pwm_period_us)
 
         :ok =
           GenericController.set_external_pwm(
@@ -186,6 +191,20 @@ defmodule VmsCore.Components.Traxxas.Throttle do
             duty_cycle_percentage,
             @pwm_frequency
           )
+
+        Bus.broadcast("messages", %Bus.Message{
+          name: :throttle,
+          value: throttle,
+          source: __MODULE__
+        })
+
+        # This is the command before CAN/timer quantisation, not an ESC
+        # readback. It makes the start threshold measurable on the car.
+        Bus.broadcast("messages", %Bus.Message{
+          name: :pulse_width_us,
+          value: pulse_width_us,
+          source: __MODULE__
+        })
 
         %{state | throttle: throttle}
     end
@@ -225,11 +244,13 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   lands on `[start_offset, cap]`.
   """
   def shape(requested, true = _linear, curve) do
-    requested |> D.abs() |> D.mult(cap(requested, curve)) |> signed_as(requested)
+    requested |> D.abs() |> D.min(@one) |> D.mult(cap(requested, curve)) |> signed_as(requested)
   end
 
   def shape(requested, false, curve) do
     requested
+    |> D.max(D.negate(@one))
+    |> D.min(@one)
     |> strip_deadzone(curve.deadzone)
     |> blend(curve.expo)
     |> offset(curve.start_offset, cap(requested, curve))

--- a/vms/core/test/components/traxxas/source_switching_test.exs
+++ b/vms/core/test/components/traxxas/source_switching_test.exs
@@ -82,6 +82,29 @@ defmodule VmsCore.Components.Traxxas.SourceSwitchingTest do
   defp source_message(name, value, source), do: %Message{name: name, value: value, source: source}
 
   describe "a level that commands nothing" do
+    test "sends neutral on the first tick even before a commander is selected" do
+      {:ok, controller} = FakeController.start_link(self())
+      OvcsBus.subscribe("messages")
+
+      {:ok, state} =
+        Throttle.init(%{
+          controller: controller,
+          external_pwm_id: 1,
+          selected_control_level_source: @manager
+        })
+
+      {:ok, :cancel} = :timer.cancel(state.loop_timer)
+      {:noreply, state} = Throttle.handle_info(:loop, state)
+
+      assert_received {:pwm, 1, true, duty, 100}
+      assert D.eq?(duty, D.new("0.15"))
+      assert_received %Message{name: :pulse_width_us, value: pulse, source: Throttle}
+      assert D.eq?(pulse, D.new(1500))
+
+      {:noreply, _state} = Throttle.handle_info(:loop, state)
+      refute_received {:pwm, _, _, _, _}
+    end
+
     test "zeroes the throttle rather than holding it" do
       # The dangerous case: driving at 0.6, switched to a level with no
       # commander. Holding would keep the vehicle moving.
@@ -293,6 +316,58 @@ defmodule VmsCore.Components.Traxxas.SourceSwitchingTest do
   end
 
   describe "the cap" do
+    test "an out-of-range request cannot exceed either cap" do
+      curve = Throttle.curve(%{max_throttle: D.new("0.1"), max_reverse: D.new("0.2")})
+
+      for linear <- [false, true] do
+        assert D.eq?(Throttle.shape(D.new(2), linear, curve), D.new("0.1"))
+        assert D.eq?(Throttle.shape(D.new(-2), linear, curve), D.new("-0.2"))
+      end
+    end
+
+    test "a narrow pulse range remains progressive and is reported after shaping" do
+      {:ok, controller} = FakeController.start_link(self())
+      OvcsBus.subscribe("messages")
+
+      curve =
+        Throttle.curve(%{
+          deadzone: D.new("0.05"),
+          expo: D.new("0.5"),
+          start_offset: D.new("0.02"),
+          max_throttle: D.new("0.1"),
+          max_reverse: D.new("0.2")
+        })
+
+      state = throttle_state(%{controller: controller, curve: curve, throttle: nil})
+
+      # 0.525 is the midpoint of the usable trigger travel after deadzone.
+      for {request, expected_pulse} <- [
+            {"0.05", "1500"},
+            {"0.052", "1510.042193905817174515235457"},
+            {"0.525", "1525"},
+            {"1", "1550"},
+            {"-1", "1400"},
+            {"0", "1500"}
+          ],
+          reduce: state do
+        state ->
+          {:noreply, state} =
+            Throttle.handle_info(:loop, %{state | requested_throttle: D.new(request)})
+
+          assert_received {:pwm, 1, true, duty, 100}
+
+          assert_in_delta D.to_float(D.mult(duty, 10_000)),
+                          D.to_float(D.new(expected_pulse)),
+                          0.000001
+
+          assert_received %Message{name: :pulse_width_us, value: pulse, source: Throttle}
+          assert D.eq?(D.div(pulse, 10_000), duty)
+          assert_received %Message{name: :throttle, value: output, source: Throttle}
+          assert D.eq?(output, state.throttle)
+          state
+      end
+    end
+
     test "scales a hand's output onto [start_offset, max_throttle]" do
       # Scaled, not clipped: full trigger still means "as fast as
       # allowed", so the whole travel stays useful.


### PR DESCRIPTION
## What

In the Mini's VMS composer: `@throttle_max` 0.5 → 0.1, `@throttle_max_reverse` 1 → 0.2, `@max_speed_m_s` 2.5 → 0.5.

## Why

At half the pulse range (1750 µs at full trigger) the truck was far too fast for where it drives. The ESC was then calibrated against this actuator's full 1000-2000 µs range (EZ-Set with an uncapped build: neutral, full throttle, full brake), so the cap is a fraction of what the ESC actually knows; at a fifth (1600 µs) it was still too fast on the road. A tenth is 1550 µs at full trigger. `start_offset` (0.06) is unchanged, so the trigger's travel spans from the edge of motion to that pulse with nothing wasted.

Reverse is capped too, at a fifth. On this ESC the first pull into negative is proportional braking, so the reverse cap is also the braking force: at the speeds the forward cap allows, a fifth of it stops the truck, and an uncapped reverse was as fast as the uncapped forward (the speed sensor read 50 km/h in reverse).

The planner's velocity path normalises m/s against the speed reached at the forward cap, so the estimate follows it. 0.5 m/s is a tenth of the 5 m/s uncapped estimate — an ESC is not linear, so this is a placeholder until the pulse speed sensor measures the speed at full trigger under the cap. Two readings are still owed and would make both numbers real: the throttle output at which the wheels first move (`start_offset`) and the speed at the cap (`@max_speed_m_s`).

## Verified

On the car, sampled from the VMS while driving in `:radio`: full trigger produced exactly the capped output (0.200 with the previous value), so the actuator applies the cap as designed. Driven at 0.2; the 0.1 / 0.2 build is built, driving pending.