### PR TITLE
fix(compute): match the uplink radio by driver, not by name

### DIFF
--- a/compose/compute/host/system-connections/ovcs0-ap.nmconnection.example
+++ b/compose/compute/host/system-connections/ovcs0-ap.nmconnection.example
@@ -13,9 +13,10 @@
 # Requires `"country":"BE"` in /mnt/boot/config.json. Without a country
 # the phy sits in regulatory domain 00, where AP mode cannot beacon.
 #
-# interface-name is the AX210's stable PCI-path name. The onboard
-# Broadcom radio stays wlan0; this one is derived from its slot, so
-# probe order cannot swap them.
+# interface-name is the AX210's stable PCI-path name, derived from its
+# slot, so probe order cannot change it. The onboard Broadcom radio has
+# no such name (wlan0 or wlan1, depending on who registered first),
+# which is why uplink.nmconnection matches it by driver instead.
 #
 # channel: pick one clear of nearby APs — `nmcli device wifi list` on
 # the device shows what is around. NetworkManager 1.52 also exposes

--- a/compose/compute/host/system-connections/uplink.nmconnection.example
+++ b/compose/compute/host/system-connections/uplink.nmconnection.example
@@ -3,29 +3,35 @@
 # this: what it adds is a route off the vehicle (balena OTA, the cloud
 # SSH tunnel, NTP) and the address a laptop on the site Wi-Fi reaches
 # Foxglove and the balena host at. Reserve that lease on the site router
-# for wlan0's MAC if a stable URL matters. The same site network goes in
+# for the onboard radio's MAC if a stable URL matters. The same site network goes in
 # the vehicle's WIFI_NETWORKS so each Nerves board joins it too.
 #
 # Separate phy from the AX210, so the AP's channel and this link's
-# channel do not constrain each other. Note that the phy *indices* are
-# assigned in probe order and do swap between boots, so never identify
-# either radio by `phy#N` — go through the interface name.
+# channel do not constrain each other.
 #
-# wlan0 is a safe pin even though the boot log can show the AX210
-# transiently claiming that name ("wlP1p1s0: renamed from wlan0"): the
-# AX210 is always renamed to its PCI-path name, so the onboard SDIO
-# radio, which has no predictable name to be given, always ends up as
-# wlan0. Add a `[match] driver=brcmfmac` section if a third radio ever
-# joins the box.
+# Matched by driver, not by name. The kernel hands out wlan0 to
+# whichever radio registers first, and on a boot where the AX210 got it
+# ("wlP1p1s0: renamed from wlan0" in the log) the onboard radio ends up
+# as wlan1 for good — the AX210's rename to its PCI-path name frees
+# wlan0 but nothing renames the Broadcom after the fact. A profile
+# pinned to wlan0 then never activates: no uplink, no NTP, no cloud
+# tunnel, and the compute node unreachable from the site Wi-Fi. The
+# brcmfmac driver is the one thing about the onboard radio that never
+# changes. Do not add an interface-name; with `[match]` present it
+# would have to agree on every boot.
 #
 # `method=auto` and no [ipv4] address: this side takes a lease. Leave
 # it as the only default route on the box — the bridge deliberately
-# installs none.
+# installs none. autoconnect-priority outranks any profile
+# NetworkManager generates for the radio on its own.
 
 [connection]
 id=uplink
 type=wifi
-interface-name=wlan0
+autoconnect-priority=10
+
+[match]
+driver=brcmfmac
 
 [wifi]
 mode=infrastructure

--- a/docs/ros_compute_node.md
+++ b/docs/ros_compute_node.md
@@ -173,14 +173,14 @@ Two networks, each doing the one thing it is good at:
   where internet (balena OTA, the cloud tunnel, NTP) comes from.
 
 ```
-            site Wi-Fi ── wlan0 of the compute node (uplink, default route)
+            site Wi-Fi ── onboard radio of the compute node (uplink, default route)
                        ── wlan0 of each Nerves board (WIFI_NETWORKS)
                               │  NAT
         ┌─────────────────────┴──────────────────────────┐
         │  ovcs0   10.42.0.1/24    NetworkManager bridge │
         │    ipv4.method=shared →                        │
         │      dnsmasq: DHCP .10-.254 + DNS              │
-        │      MASQUERADE out via wlan0                  │
+        │      MASQUERADE out via the uplink             │
         └────┬────────────────────────────┬──────────────┘
              │                            │
           eth0                      wlP1p1s0  (AX210 AP "OVCS-Mini", 2.4 GHz)
@@ -205,7 +205,7 @@ board is still reachable through the access point.
 
 The onboard radio of the compute node is deliberately not load-bearing
 either. `method=shared` assigns the bridge address, starts dnsmasq and
-installs the NAT rule unconditionally; if `wlan0` is unassociated,
+installs the NAT rule unconditionally; if the uplink is unassociated,
 clients still get leases and full vehicle-local connectivity and simply
 have no route off the car.
 
@@ -246,7 +246,7 @@ A laptop on the site Wi-Fi reaches each Nerves board directly, at its
 own site address, by mDNS: `ping ovcs-mini-vms.local`, `./ovcs connect
 ovcs_mini vms`, the dashboard at `http://ovcs-mini-vms.local:4000`.
 Foxglove attaches to the compute node's site address (the `uplink`
-lease — reserve it on the site router for `wlan0`'s MAC if a stable URL
+lease — reserve it on the site router for the onboard radio's MAC if a stable URL
 matters).
 
 What that laptop does *not* have is a route into `10.42.0.0/24`:
@@ -353,7 +353,7 @@ into **both** directories, then:
    `balena-config-vars --no-cache` to verify, and remember the value
    only reaches the driver at the next boot.
 3. `chmod 600` the `/etc` copies and `nmcli connection reload`.
-4. `nmcli con up uplink && ip -4 addr show wlan0` — this address is the
+4. `nmcli con up uplink && nmcli -f IP4.ADDRESS con show uplink` — this address is the
    way in from now on; open a second SSH session on it.
 5. `nmcli con up ovcs0`. Join the access point from a laptop and check
    it gets a lease in `10.42.0.0/24` and can reach `10.42.0.1`.
@@ -368,7 +368,8 @@ Activating `ovcs0-eth0` converts `eth0` from DHCP client to DHCP
 into, so:
 
 1. Be connected over the `uplink` address, and confirm the cloud tunnel
-   is on it: `ip route get 1.1.1.1` should name `wlan0`.
+   is on it: `ip route get 1.1.1.1` should name the onboard radio
+   (`wlan0` or `wlan1` — see the `uplink` keyfile for why it varies).
 2. **Move `eth0` to the vehicle's own switch**, with the switch
    disconnected from any site LAN. On an office LAN this would become
    a rogue DHCP server the moment step 3 lands.
@@ -407,7 +408,7 @@ ip -4 addr show ovcs0                # 10.42.0.1/24
 ls /sys/class/net/ovcs0/brif/        # eth0 wlP1p1s0
 cat /var/lib/NetworkManager/dnsmasq-ovcs0.leases   # one line per board
 iptables -t nat -S POSTROUTING | head -2           # ovcs-bridge-no-nat before nm-shared-ovcs0
-ip route | grep default              # exactly one, via wlan0
+ip route | grep default              # exactly one, via the onboard radio (wlan0 or wlan1)
 journalctl -k -b | grep iwlwifi      # "loaded firmware" and "loaded PNVM"
 
 # From a laptop on the site Wi-Fi, then again on the access point
@@ -515,7 +516,7 @@ What is left:
    today; HT40 roughly doubles throughput for a laptop on the access
    point but needs ch 3-9, which is where the site's other APs already
    are.
-2. A reservation on the site router for the compute node's `wlan0`, so
+2. A reservation on the site router for the compute node's onboard radio, so
    the Foxglove URL stops moving.
 
 Next: [Running on Hardware](./running_hardware.md)


### PR DESCRIPTION
## What

`uplink.nmconnection.example` matches the onboard radio with `[match] driver=brcmfmac` instead of `interface-name=wlan0`; the doc and the AP keyfile's comment stop asserting that the onboard radio is always `wlan0`.

## Why

Found on the Mini after a reboot: the onboard radio was `wlan1`. The kernel gives `wlan0` to the first radio to register, and on that boot it was the AX210 (`wlP1p1s0: renamed from wlan0`). The AX210's rename to its PCI-path name frees `wlan0`, but the Broadcom, already registered as `wlan1`, keeps that name. The `uplink` profile, pinned to `wlan0`, never activated. Consequences on the car: no default route, no NTP (chronyd waits on `timesync-https`, which waits on the internet; the compute node's clock was 3 h 35 behind the boards'), no balena cloud tunnel, and the compute node unreachable from the site Wi-Fi.

The old comment claimed `wlan0` was a safe pin because the AX210 is always renamed away from it. That is true and irrelevant: the race is about who registers first, not about the final names.

## Verified

The corrected keyfile is installed on the Mini; activation and the clock catching up are the confirmation (pending at the time of writing).