### PR TITLE
fix(ros_bridge): restart a camera whose frames stop arriving

### DIFF
--- a/bridges/ros_bridge/lib/ros_bridge/camera/lib_camera.ex
+++ b/bridges/ros_bridge/lib/ros_bridge/camera/lib_camera.ex
@@ -24,6 +24,26 @@ defmodule RosBridge.Camera.LibCamera do
 
   The Port supervises the binary: closing stdin (which happens
   when this GenServer dies) tells the binary to exit cleanly.
+
+  ## Stall watchdog
+
+  A capture can stop delivering frames without the binary exiting:
+  libcamera keeps the process alive, sleeping on its request queue,
+  and nothing on this side would ever notice — the port stays open,
+  the supervisor sees a healthy child, and the fabric simply carries
+  no more images. Both cameras of a stereo pair have been seen doing
+  exactly that a few seconds after boot, until the drivers were
+  restarted by hand.
+
+  So the driver watches its own frame flow. Once frames have started,
+  `:stall_timeout_ms` (default 2000 ms — sixty frame periods at 30 fps)
+  of silence is a stall; before the first frame, `:startup_timeout_ms`
+  (default 15000 ms, libcamera's pipeline set-up on a Pi 5 can take a
+  few seconds) is the most a camera gets to produce one. Either way the
+  driver logs the reason and stops, and the stereo supervisor's
+  `:rest_for_one` restarts it together with everything downstream, which
+  re-runs the listener registrations. The binary is relaunched by the
+  restart, and with it libcamera's pipeline.
   """
   @behaviour RosBridge.Camera
 
@@ -33,6 +53,9 @@ defmodule RosBridge.Camera.LibCamera do
   alias RosBridge.Camera.Frame
 
   @frame_tag 1
+  @watchdog_interval_ms 1_000
+  @default_stall_timeout_ms 2_000
+  @default_startup_timeout_ms 15_000
 
   def start_link(opts) do
     label = Keyword.fetch!(opts, :label)
@@ -83,12 +106,18 @@ defmodule RosBridge.Camera.LibCamera do
       "#{__MODULE__}[#{label}] camera #{camera_id} @ #{width}×#{height}/#{fps}fps via #{executable}"
     )
 
+    Process.send_after(self(), :watchdog, @watchdog_interval_ms)
+
     {:ok,
      %{
        label: label,
        camera_id: camera_id,
        port: port,
-       listeners: []
+       listeners: [],
+       started_at: now_ms(),
+       last_frame_at: nil,
+       stall_timeout_ms: Keyword.get(opts, :stall_timeout_ms, @default_stall_timeout_ms),
+       startup_timeout_ms: Keyword.get(opts, :startup_timeout_ms, @default_startup_timeout_ms)
      }}
   end
 
@@ -98,20 +127,43 @@ defmodule RosBridge.Camera.LibCamera do
       {:ok, %Frame{} = frame} ->
         frame = %{frame | label: state.label}
         Enum.each(state.listeners, &GenServer.cast(&1, {:camera_frame, frame}))
+        {:noreply, %{state | last_frame_at: now_ms()}}
 
       {:error, reason} ->
         Logger.warning(
           "#{__MODULE__}[#{state.label}] dropping malformed record: #{inspect(reason)}"
         )
-    end
 
-    {:noreply, state}
+        {:noreply, state}
+    end
   end
 
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
     Logger.error("#{__MODULE__}[#{state.label}] camera_capture exited with status #{status}")
 
     {:stop, {:camera_capture_exit, status}, state}
+  end
+
+  def handle_info(:watchdog, state) do
+    case stall_verdict(state, now_ms()) do
+      :ok ->
+        Process.send_after(self(), :watchdog, @watchdog_interval_ms)
+        {:noreply, state}
+
+      {:stalled, silent_ms} ->
+        Logger.error(
+          "#{__MODULE__}[#{state.label}] no frame for #{silent_ms} ms; restarting camera_capture"
+        )
+
+        {:stop, {:camera_stall, silent_ms}, state}
+
+      {:no_first_frame, waited_ms} ->
+        Logger.error(
+          "#{__MODULE__}[#{state.label}] no frame #{waited_ms} ms after start; restarting camera_capture"
+        )
+
+        {:stop, {:camera_stall, :no_first_frame}, state}
+    end
   end
 
   @impl true
@@ -126,6 +178,25 @@ defmodule RosBridge.Camera.LibCamera do
 
   @impl RosBridge.Camera
   def enable(_server), do: :ok
+
+  @doc """
+  The watchdog's decision for a driver state at `now_ms`: `:ok`,
+  `{:stalled, silent_ms}` once frames have flowed and then stopped for
+  longer than `:stall_timeout_ms`, or `{:no_first_frame, waited_ms}`
+  when nothing has arrived `:startup_timeout_ms` after start. Pure, so
+  the two timeouts can be checked without a camera.
+  """
+  def stall_verdict(%{last_frame_at: nil} = state, now_ms) do
+    waited = now_ms - state.started_at
+    if waited > state.startup_timeout_ms, do: {:no_first_frame, waited}, else: :ok
+  end
+
+  def stall_verdict(state, now_ms) do
+    silent = now_ms - state.last_frame_at
+    if silent > state.stall_timeout_ms, do: {:stalled, silent}, else: :ok
+  end
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
 
   defp parse_record(<<
          @frame_tag,

--- a/bridges/ros_bridge/test/ros_bridge/camera/lib_camera_test.exs
+++ b/bridges/ros_bridge/test/ros_bridge/camera/lib_camera_test.exs
@@ -5,7 +5,12 @@ defmodule RosBridge.Camera.LibCameraTest do
 
   # The driver itself needs the native binary and two cameras; the
   # watchdog's decision is the part that can be wrong, and it is pure.
-  @state %{started_at: 1_000, last_frame_at: nil, stall_timeout_ms: 2_000, startup_timeout_ms: 15_000}
+  @state %{
+    started_at: 1_000,
+    last_frame_at: nil,
+    stall_timeout_ms: 2_000,
+    startup_timeout_ms: 15_000
+  }
 
   describe "stall_verdict/2" do
     test "waits for the first frame up to the startup timeout" do

--- a/bridges/ros_bridge/test/ros_bridge/camera/lib_camera_test.exs
+++ b/bridges/ros_bridge/test/ros_bridge/camera/lib_camera_test.exs
@@ -1,0 +1,30 @@
+defmodule RosBridge.Camera.LibCameraTest do
+  use ExUnit.Case, async: true
+
+  alias RosBridge.Camera.LibCamera
+
+  # The driver itself needs the native binary and two cameras; the
+  # watchdog's decision is the part that can be wrong, and it is pure.
+  @state %{started_at: 1_000, last_frame_at: nil, stall_timeout_ms: 2_000, startup_timeout_ms: 15_000}
+
+  describe "stall_verdict/2" do
+    test "waits for the first frame up to the startup timeout" do
+      assert LibCamera.stall_verdict(@state, 1_000 + 15_000) == :ok
+      assert LibCamera.stall_verdict(@state, 1_000 + 15_001) == {:no_first_frame, 15_001}
+    end
+
+    test "tolerates silence up to the stall timeout once frames have flowed" do
+      flowing = %{@state | last_frame_at: 40_000}
+      assert LibCamera.stall_verdict(flowing, 40_000 + 33) == :ok
+      assert LibCamera.stall_verdict(flowing, 40_000 + 2_000) == :ok
+      assert LibCamera.stall_verdict(flowing, 40_000 + 2_001) == {:stalled, 2_001}
+    end
+
+    test "the startup timeout no longer applies after the first frame" do
+      # A camera that started long ago but delivered a frame just now is
+      # fine however slow its start was.
+      late_starter = %{@state | last_frame_at: 1_000 + 60_000}
+      assert LibCamera.stall_verdict(late_starter, 1_000 + 60_500) == :ok
+    end
+  end
+end


### PR DESCRIPTION
## What

`RosBridge.Camera.LibCamera` gets a stall watchdog: once frames have started, `:stall_timeout_ms` (default 2000 ms) of silence stops the driver; before the first frame, `:startup_timeout_ms` (default 15000 ms) is the most a camera gets to produce one. The stereo supervisor's existing `:rest_for_one` then relaunches `camera_capture` and re-registers the publisher. The decision (`stall_verdict/2`) is pure and unit-tested.

## Why

Seen on the Mini: both stereo captures stopped a few seconds after boot. `camera_capture` processes alive (sleeping in `hrtimer_nanosleep`), ports open, no error anywhere, frame counters frozen at 431 per side, and no image topic on the fabric. Killing the two driver processes brought frames back at 30 fps and the eight `/stereo/*` topics with them. The cause of the libcamera stall is not identified; whatever it is, the pipeline must not depend on someone noticing.

## Verified

`mix compile --warnings-as-errors` and the three new tests pass. Not yet driven on the board — the perception firmware with this change is the next upload.