### PR TITLE
Reduce Foxglove Wi-Fi traffic and stabilize the onboard uplink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent instructions
+
+Read and follow [CLAUDE.md](./CLAUDE.md) for this repository's project guidance
+and workflow rules. Read [CODE_STYLING.md](./CODE_STYLING.md) before non-trivial
+changes.
+
+References to Claude apply to the assistant working in this repository. For
+AI assistance disclosure, use the actual assistant and model identity rather
+than copying the Claude-specific example.

--- a/compose/compute/README.md
+++ b/compose/compute/README.md
@@ -36,6 +36,44 @@ balena push <device>.local         # local mode: build on the device, no cloud
 Runtime configuration is balena fleet/device variables, not a `.env`
 file.
 
+### Foxglove on slower Wi-Fi
+
+The public endpoint remains `ws://<compute-node-ip>:8765`. A local relay
+negotiates WebSocket `permessage-deflate` with compatible clients and forwards
+the original Foxglove text and binary messages in both directions using the
+bridge's `foxglove.sdk.v1` subprotocol. Compression
+is lossless: topics, frame rates, image resolution and layouts are unchanged.
+Clients without compression support can still connect, without the bandwidth
+savings. The relay logs the negotiated extension for each connection.
+
+The ROS bridge listens on loopback port 8766, configurable with
+`FOXGLOVE_BRIDGE_INTERNAL_PORT`; the public port uses `FOXGLOVE_BRIDGE_PORT`.
+Both processes run in the bridge container and a child failure exits the
+service so the supervisor can restart it. The relay uses compression level 1,
+a receive high-water mark of one frame and a 32 KiB write high-water mark.
+These limits propagate slow-client backpressure to the bridge rather than
+adding an unbounded application queue. Kernel socket buffers still apply.
+
+The bridge limits each client's outgoing queue to 32 messages with
+`FOXGLOVE_MESSAGE_BACKLOG_SIZE` (Foxglove Bridge 3.4.1 or later). Set this
+fleet/device variable to override the limit; it is read at startup.
+When the queue fills, the SDK drops the oldest data messages. This keeps
+less stale data queued without changing the layout or source topics.
+The limit is in messages, not bytes, and does not bound TCP buffers or
+reduce the source bandwidth. A full control-message queue disconnects
+the client, so check reconnections when reducing the limit further.
+
+The 3.4.3 bridge still declares `use_compression` and `send_buffer_limit`,
+but its SDK-backed WebSocket initialization does not use them. Do not
+rely on those parameters for compression or a byte-based queue limit.
+See the [versioned bridge source](https://github.com/foxglove/foxglove-sdk/blob/ros-v3.4.3/ros/src/foxglove_bridge/src/ros2_foxglove_bridge.cpp).
+
+Run the relay integration tests in an environment with `websockets==17.0.1`:
+
+```sh
+python3 -m unittest discover -s images/ros2/docker/tests -v
+```
+
 ### Rehearsing on a workstation
 
 The file is plain Compose (a subset of it), so it also runs on any

--- a/compose/compute/host/system-connections/uplink.nmconnection.example
+++ b/compose/compute/host/system-connections/uplink.nmconnection.example
@@ -3,7 +3,7 @@
 # this: what it adds is a route off the vehicle (balena OTA, the cloud
 # SSH tunnel, NTP) and the address a laptop on the site Wi-Fi reaches
 # Foxglove and the balena host at. Reserve that lease on the site router
-# for wlan0's MAC if a stable URL matters. The same site network goes in
+# for the onboard radio's MAC if a stable URL matters. The same site network goes in
 # the vehicle's WIFI_NETWORKS so each Nerves board joins it too.
 #
 # Separate phy from the AX210, so the AP's channel and this link's
@@ -11,12 +11,8 @@
 # assigned in probe order and do swap between boots, so never identify
 # either radio by `phy#N` — go through the interface name.
 #
-# wlan0 is a safe pin even though the boot log can show the AX210
-# transiently claiming that name ("wlP1p1s0: renamed from wlan0"): the
-# AX210 is always renamed to its PCI-path name, so the onboard SDIO
-# radio, which has no predictable name to be given, always ends up as
-# wlan0. Add a `[match] driver=brcmfmac` section if a third radio ever
-# joins the box.
+# Match the onboard driver: its interface can be wlan0 or wlan1,
+# depending on whether the AX210 claimed wlan0 before being renamed.
 #
 # `method=auto` and no [ipv4] address: this side takes a lease. Leave
 # it as the only default route on the box — the bridge deliberately
@@ -25,7 +21,9 @@
 [connection]
 id=uplink
 type=wifi
-interface-name=wlan0
+
+[match]
+driver=brcmfmac
 
 [wifi]
 mode=infrastructure

--- a/compose/compute/images/ros2/Dockerfile
+++ b/compose/compute/images/ros2/Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get update \
         python3-pip \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install --no-cache-dir --break-system-packages \
-        eclipse-zenoh==1.9.0
+        eclipse-zenoh==1.9.0 \
+        websockets==17.0.1
 
 # Baked in rather than bind-mounted: balenaOS has no host bind mounts,
 # and keeping one mechanism means the vehicle and the base station read
@@ -50,6 +51,7 @@ COPY zenoh/session.json5.template /etc/zenoh/session.json5.template
 # docker/calibrator.sh is mode 644 in git.
 COPY docker/entrypoint.sh         /usr/local/bin/entrypoint
 COPY docker/foxglove_bridge.sh    /usr/local/bin/foxglove_bridge
+COPY docker/foxglove_compression.py /usr/local/bin/foxglove_compression
 COPY docker/joy.sh                /usr/local/bin/joy
 COPY docker/calibrator.sh         /usr/local/bin/calibrator
 COPY docker/decompress_stereo.py  /usr/local/bin/decompress_stereo

--- a/compose/compute/images/ros2/docker/foxglove_bridge.sh
+++ b/compose/compute/images/ros2/docker/foxglove_bridge.sh
@@ -7,10 +7,42 @@
 set -euo pipefail
 
 : "${FOXGLOVE_BRIDGE_PORT:=8765}"
+: "${FOXGLOVE_BRIDGE_INTERNAL_PORT:=8766}"
+: "${FOXGLOVE_MESSAGE_BACKLOG_SIZE:=32}"
+
+# Bound stale data waiting for a slow WebSocket client. The SDK drops
+# the oldest data message when this per-client queue is full.
 
 echo "foxglove_bridge: listening on ws://0.0.0.0:${FOXGLOVE_BRIDGE_PORT}, peering with ${ZENOH_ENDPOINT_IP}:7447"
 
-exec ros2 run foxglove_bridge foxglove_bridge \
+bridge_executable="$(ros2 pkg prefix foxglove_bridge)/lib/foxglove_bridge/foxglove_bridge"
+child_pids=()
+cleanup() {
+  trap - EXIT INT TERM
+  if ((${#child_pids[@]})); then
+    kill "${child_pids[@]}" 2>/dev/null || true
+    wait "${child_pids[@]}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+trap 'exit 0' INT TERM
+
+"${bridge_executable}" \
   --ros-args \
-  -p port:="${FOXGLOVE_BRIDGE_PORT}" \
-  -p address:=0.0.0.0
+  -p port:="${FOXGLOVE_BRIDGE_INTERNAL_PORT}" \
+  -p address:=127.0.0.1 \
+  -p message_backlog_size:="${FOXGLOVE_MESSAGE_BACKLOG_SIZE}" &
+child_pids+=("$!")
+
+python3 /usr/local/bin/foxglove_compression \
+  --port "${FOXGLOVE_BRIDGE_PORT}" \
+  --upstream-port "${FOXGLOVE_BRIDGE_INTERNAL_PORT}" &
+child_pids+=("$!")
+
+# A failed child must restart the whole service, not leave a half-working relay.
+status=0
+wait -n "${child_pids[@]}" || status=$?
+if ((status == 0)); then
+  status=1
+fi
+exit "${status}"

--- a/compose/compute/images/ros2/docker/foxglove_compression.py
+++ b/compose/compute/images/ros2/docker/foxglove_compression.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Relay Foxglove messages with lossless WebSocket compression."""
 
 import argparse

--- a/compose/compute/images/ros2/docker/foxglove_compression.py
+++ b/compose/compute/images/ros2/docker/foxglove_compression.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Relay Foxglove messages with lossless WebSocket compression."""
+
+import argparse
+import asyncio
+import logging
+import signal
+
+from websockets.asyncio.client import connect
+from websockets.asyncio.server import serve
+from websockets.exceptions import ConnectionClosed, InvalidHandshake
+from websockets.extensions.permessage_deflate import ServerPerMessageDeflateFactory
+
+PROTOCOL = "foxglove.sdk.v1"
+LOG = logging.getLogger("foxglove_compression")
+
+
+async def forward(source, destination):
+    async for message in source:
+        await destination.send(message)
+
+
+async def relay(client, upstream_uri):
+    """Give each client its own upstream session and preserve message ordering."""
+    try:
+        async with connect(
+            upstream_uri,
+            subprotocols=[PROTOCOL],
+            compression=None,
+            proxy=None,
+            max_size=None,
+            max_queue=1,
+            write_limit=32768,
+            close_timeout=2,
+        ) as upstream:
+            LOG.info(
+                "Client connected; compression=%s",
+                client.response.headers.get("Sec-WebSocket-Extensions", "none"),
+            )
+            tasks = [
+                asyncio.create_task(forward(upstream, client)),
+                asyncio.create_task(forward(client, upstream)),
+            ]
+            try:
+                done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                for task in done:
+                    task.result()
+            finally:
+                for task in tasks:
+                    task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+    except ConnectionClosed:
+        pass
+    except (OSError, TimeoutError, InvalidHandshake) as error:
+        LOG.warning("Bridge connection failed: %s", error)
+        await client.close(code=1013, reason="Bridge unavailable; reconnect")
+
+
+def compression_extensions():
+    # Level 1 keeps compression work small on the vehicle CPU. Independent
+    # messages bound compression state and match the measured per-frame cost.
+    return [
+        ServerPerMessageDeflateFactory(
+            server_no_context_takeover=True,
+            compress_settings={"level": 1},
+        )
+    ]
+
+
+async def run(args):
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, stop.set)
+
+    async def handler(client):
+        await relay(client, f"ws://127.0.0.1:{args.upstream_port}")
+
+    async with serve(
+        handler,
+        "0.0.0.0",
+        args.port,
+        subprotocols=[PROTOCOL],
+        extensions=compression_extensions(),
+        compression=None,
+        max_size=None,
+        max_queue=1,
+        write_limit=32768,
+        close_timeout=2,
+    ):
+        LOG.info("Listening on port %d; upstream on loopback:%d", args.port, args.upstream_port)
+        await stop.wait()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--upstream-port", type=int, required=True)
+    args = parser.parse_args()
+    if not (1 <= args.port <= 65535 and 1 <= args.upstream_port <= 65535):
+        parser.error("ports must be between 1 and 65535")
+    if args.port == args.upstream_port:
+        parser.error("public and upstream ports must differ")
+    logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+    asyncio.run(run(args))

--- a/compose/compute/images/ros2/docker/tests/test_foxglove_compression.py
+++ b/compose/compute/images/ros2/docker/tests/test_foxglove_compression.py
@@ -2,8 +2,8 @@
 
 import asyncio
 import importlib.util
-from pathlib import Path
 import unittest
+from pathlib import Path
 
 from websockets.asyncio.client import connect
 from websockets.asyncio.server import serve
@@ -58,14 +58,16 @@ class CompressionRelayTest(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(await asyncio.wait_for(peer.recv(), 3), message)
 
     async def test_clients_have_separate_sessions_and_compression_is_optional(self):
-        async with connect(self.uri, subprotocols=[relay.PROTOCOL]) as first:
-            async with connect(self.uri, subprotocols=[relay.PROTOCOL], compression=None) as second:
-                self.assertNotIn("Sec-WebSocket-Extensions", second.response.headers)
-                await first.send("first")
-                await second.send("second")
-                self.assertEqual(await asyncio.wait_for(first.recv(), 3), "first")
-                self.assertEqual(await asyncio.wait_for(second.recv(), 3), "second")
-                self.assertEqual(self.upstream_connections, 2)
+        async with (
+            connect(self.uri, subprotocols=[relay.PROTOCOL]) as first,
+            connect(self.uri, subprotocols=[relay.PROTOCOL], compression=None) as second,
+        ):
+            self.assertNotIn("Sec-WebSocket-Extensions", second.response.headers)
+            await first.send("first")
+            await second.send("second")
+            self.assertEqual(await asyncio.wait_for(first.recv(), 3), "first")
+            self.assertEqual(await asyncio.wait_for(second.recv(), 3), "second")
+            self.assertEqual(self.upstream_connections, 2)
 
     async def test_upstream_close_terminates_client_session(self):
         async with connect(self.uri, subprotocols=[relay.PROTOCOL]) as peer:

--- a/compose/compute/images/ros2/docker/tests/test_foxglove_compression.py
+++ b/compose/compute/images/ros2/docker/tests/test_foxglove_compression.py
@@ -1,0 +1,78 @@
+"""Exercise the relay against real WebSocket peers without requiring ROS."""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import unittest
+
+from websockets.asyncio.client import connect
+from websockets.asyncio.server import serve
+from websockets.exceptions import ConnectionClosed
+
+spec = importlib.util.spec_from_file_location(
+    "foxglove_compression", Path(__file__).resolve().parents[1] / "foxglove_compression.py"
+)
+relay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(relay)
+
+
+class CompressionRelayTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.upstream_connections = 0
+
+        async def echo(peer):
+            self.upstream_connections += 1
+            async for message in peer:
+                if message == "close-upstream":
+                    await peer.close()
+                    return
+                await peer.send(message)
+
+        self.upstream = await serve(
+            echo, "127.0.0.1", 0, subprotocols=[relay.PROTOCOL],
+            compression=None, max_size=None,
+        )
+        upstream_port = self.upstream.sockets[0].getsockname()[1]
+
+        async def handler(peer):
+            await relay.relay(peer, f"ws://127.0.0.1:{upstream_port}")
+
+        self.proxy = await serve(
+            handler, "127.0.0.1", 0, subprotocols=[relay.PROTOCOL],
+            compression=None, extensions=relay.compression_extensions(), max_size=None,
+        )
+        self.uri = f"ws://127.0.0.1:{self.proxy.sockets[0].getsockname()[1]}"
+
+    async def asyncTearDown(self):
+        self.proxy.close()
+        await self.proxy.wait_closed()
+        self.upstream.close()
+        await self.upstream.wait_closed()
+
+    async def test_compressed_text_and_large_binary_are_lossless(self):
+        async with connect(self.uri, subprotocols=[relay.PROTOCOL], max_size=None) as peer:
+            self.assertIn("permessage-deflate", peer.response.headers["Sec-WebSocket-Extensions"])
+            self.assertEqual(peer.subprotocol, relay.PROTOCOL)
+            for message in ['{"op":"subscribe","subscriptions":[]}', bytes(range(256)) * 8192]:
+                await peer.send(message)
+                self.assertEqual(await asyncio.wait_for(peer.recv(), 3), message)
+
+    async def test_clients_have_separate_sessions_and_compression_is_optional(self):
+        async with connect(self.uri, subprotocols=[relay.PROTOCOL]) as first:
+            async with connect(self.uri, subprotocols=[relay.PROTOCOL], compression=None) as second:
+                self.assertNotIn("Sec-WebSocket-Extensions", second.response.headers)
+                await first.send("first")
+                await second.send("second")
+                self.assertEqual(await asyncio.wait_for(first.recv(), 3), "first")
+                self.assertEqual(await asyncio.wait_for(second.recv(), 3), "second")
+                self.assertEqual(self.upstream_connections, 2)
+
+    async def test_upstream_close_terminates_client_session(self):
+        async with connect(self.uri, subprotocols=[relay.PROTOCOL]) as peer:
+            await peer.send("close-upstream")
+            with self.assertRaises(ConnectionClosed):
+                await asyncio.wait_for(peer.recv(), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
High-bandwidth image and point-cloud streams can accumulate delay over Wi-Fi. Add a lossless WebSocket compression relay in front of Foxglove Bridge and limit its per-client backlog to 32 messages. Topics, layouts, image resolution and source frame rates remain unchanged.

The relay uses the bridge's `foxglove.sdk.v1` protocol, preserves bidirectional messages and runs in the same container with coordinated process shutdown. Clients negotiate `permessage-deflate` automatically; clients without compression support can still connect. Document configuration and pin the relay dependency.

Match the onboard Internet uplink by the `brcmfmac` driver so it works with either `wlan0` or `wlan1`. Add `AGENTS.md` to direct coding agents to the existing project guidance.

Validation:
- Three WebSocket integration tests pass: lossless text and large binary messages, independent clients with optional compression, and upstream disconnect handling.
- Deployed on OVCS Mini and verified ROS Lyrical with Foxglove Bridge 3.4.3, negotiated compression and a backlog of 32 messages.
- A 10-second Wi-Fi measurement of both camera streams, depth, disparity and point cloud transferred 109.9 Mbit/s of decoded messages using 31.9 Mbit/s on the WebSocket connection, about 71% less traffic. Cameras remained at 30 Hz and depth, disparity and point cloud at 15 Hz.
- Confirmed the Internet route uses the onboard Wi-Fi; shell syntax and whitespace checks pass.

The backlog limit counts messages, not bytes; kernel socket buffers still apply.
