### PR TITLE
Persist the AX210 5 GHz / 80 MHz access point across reboots

### DIFF
--- a/compose/compute/docker-compose.yml
+++ b/compose/compute/docker-compose.yml
@@ -62,6 +62,12 @@ services:
   wifi_ap_fix:
     # Correct the host supplicant's channel-149 / 80 MHz center frequency
     # and restore the tested transmit-power limit after driver resets.
+    # It edits the network inside the host's wpa_supplicant over D-Bus,
+    # behind NetworkManager's back: NetworkManager rewrites that network
+    # every time it (re)activates the profile, which is why the service
+    # loops every two seconds rather than acting once. If the access
+    # point ever behaves oddly, this tug-of-war is the first suspect —
+    # `balena logs wifi_ap_fix` shows each correction it makes.
     build: ./images/wifi-ap-fix
     restart: always
     network_mode: host

--- a/compose/compute/docker-compose.yml
+++ b/compose/compute/docker-compose.yml
@@ -59,6 +59,19 @@ services:
     # `always` default and the container simply never exits (see
     # ./images/wifi-firmware/Dockerfile).
 
+  wifi_ap_fix:
+    # Correct the host supplicant's channel-149 / 80 MHz center frequency
+    # and restore the tested transmit-power limit after driver resets.
+    build: ./images/wifi-ap-fix
+    restart: always
+    network_mode: host
+    cap_add:
+      - NET_ADMIN
+    labels:
+      io.balena.features.dbus: '1'
+    environment:
+      DBUS_SYSTEM_BUS_ADDRESS: unix:path=/host/run/dbus/system_bus_socket
+
   bridge_nat_fix:
     # Keeps the host's NAT off frames the ovcs0 bridge forwards between
     # eth0 and the access point — without it mDNS between a laptop on

--- a/compose/compute/host/README.md
+++ b/compose/compute/host/README.md
@@ -16,7 +16,7 @@ topology these files implement and the install procedure.
 | File | Role |
 |---|---|
 | `system-connections/ovcs0.nmconnection.example` | the vehicle bridge — its own gateway + DHCP server |
-| `system-connections/ovcs0-ap.nmconnection.example` | the AX210 as a 2.4 GHz AP, a bridge port |
+| `system-connections/ovcs0-ap.nmconnection.example` | the AX210 as a 5 GHz / 80 MHz AP, a bridge port |
 | `system-connections/uplink.nmconnection.example` | onboard Wi-Fi as a client of the site network — internet, cloud tunnel, Foxglove |
 | `system-connections/ovcs0-eth0.nmconnection.example` | `eth0` as a bridge port — **installed last**, see below |
 
@@ -39,3 +39,38 @@ secrets out of git.
 file added to `/mnt/boot` does nothing until the next reboot. The
 install procedure writes both deliberately — see
 [Installing it](../../../docs/ros_compute_node.md#installing-it).
+
+## Persistent 5 GHz access point
+
+Deploy `wifi_ap_fix` from the compute stack before changing the AP profile.
+Copy `configure-5ghz.sh` to the balenaOS host and run it with `bash` there.
+It backs up the boot profile under `/mnt/data/ovcs-ap-before-5ghz`, creates
+the fallback and writes both profiles to the active and boot directories.
+Activate the preferred profile with `nmcli --wait 35 connection up ovcs0-ap`
+from the site-network SSH connection; the AP connection briefly drops.
+
+The service uses the host D-Bus socket to correct NetworkManager 1.52's channel-149
+VHT center from 5770 to 5775 MHz, and host networking with `NET_ADMIN` to
+restore the 6 dBm transmit-power limit. It only corrects AP networks on
+that channel and leaves an already-correct center frequency alone.
+
+The AP profile must be written to both `/etc/NetworkManager/system-connections/`
+and `/mnt/boot/system-connections/`; an `nmcli --temporary` change disappears
+on reboot. The example selects channel 149, 80 MHz, autoconnect priority 100
+and one autoconnect attempt. Keep a clone of the working 2.4 GHz profile
+named `ovcs0-ap-fallback`, with autoconnect enabled, priority -100 and one
+attempt, in both directories. This restores access if 5 GHz cannot start.
+If boot reaches the fallback before the service starts, the service retries
+the preferred profile once. A failed retry leaves NetworkManager free to
+return to the fallback instead of disconnecting clients repeatedly.
+
+After activation and after a reboot, verify on the host:
+
+```sh
+iw dev wlP1p1s0 info
+nmcli -f NAME,DEVICE connection show --active
+ip route get 1.1.1.1
+```
+
+The AP should report channel 149 (5745 MHz), width 80 MHz, center1 5775 MHz,
+and 6 dBm. The Internet route should use the onboard `brcmfmac` radio.

--- a/compose/compute/host/configure-5ghz.sh
+++ b/compose/compute/host/configure-5ghz.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run on the balenaOS host after deploying wifi_ap_fix.
+set -euo pipefail
+
+if [ -z "$(balena-engine ps -q --filter name=wifi_ap_fix)" ]; then
+  echo "Deploy and start wifi_ap_fix before configuring the AP" >&2
+  exit 1
+fi
+
+backup=/mnt/data/ovcs-ap-before-5ghz
+mkdir -p "$backup"
+chmod 700 "$backup"
+if [ ! -f "$backup/ovcs0-ap.nmconnection" ]; then
+  cp /mnt/boot/system-connections/ovcs0-ap.nmconnection "$backup/ovcs0-ap.nmconnection"
+  chmod 600 "$backup/ovcs0-ap.nmconnection"
+fi
+if ! nmcli -g connection.id connection show ovcs0-ap-fallback >/dev/null 2>&1; then
+  nmcli connection clone ovcs0-ap ovcs0-ap-fallback
+fi
+nmcli connection modify ovcs0-ap-fallback connection.autoconnect yes \
+  connection.autoconnect-priority -100 connection.autoconnect-retries 1 \
+  802-11-wireless.band bg 802-11-wireless.channel 11 802-11-wireless.channel-width 20
+fallback_uuid=$(nmcli -g connection.uuid connection show ovcs0-ap-fallback)
+fallback_file=$(grep -l "^uuid=$fallback_uuid$" /etc/NetworkManager/system-connections/*)
+cp "$fallback_file" /mnt/boot/system-connections/ovcs0-ap-fallback.nmconnection
+chmod 600 /mnt/boot/system-connections/ovcs0-ap-fallback.nmconnection
+nmcli connection modify ovcs0-ap connection.autoconnect yes \
+  connection.autoconnect-priority 100 connection.autoconnect-retries 1 \
+  802-11-wireless.band a 802-11-wireless.channel 149 802-11-wireless.channel-width 80
+preferred_uuid=$(nmcli -g connection.uuid connection show ovcs0-ap)
+preferred_file=$(grep -l "^uuid=$preferred_uuid$" /etc/NetworkManager/system-connections/*)
+cp "$preferred_file" /mnt/boot/system-connections/ovcs0-ap.nmconnection
+chmod 600 /mnt/boot/system-connections/ovcs0-ap.nmconnection
+sync
+printf 'Persistent AP and fallback profiles installed\n'

--- a/compose/compute/host/system-connections/ovcs0-ap.nmconnection.example
+++ b/compose/compute/host/system-connections/ovcs0-ap.nmconnection.example
@@ -4,6 +4,17 @@
 # 1.52: it corrects the VHT center to 5775 MHz and limits TX power to
 # 6 dBm. Deploy that service before activating this profile.
 #
+# The 6 dBm is not a tuning value. An 80 MHz channel centred on 5775 MHz
+# spans 5735-5815 MHz; the ETSI/BE table caps 5725-5875 at 13 dBm and
+# 5795-5815 is the road-tolling band, so this transmitter, on a vehicle,
+# sits inside it. The card would offer 22 dBm here. Raising the limit
+# means re-reading that table first, and the 2.4 GHz fallback profile
+# (see ../README.md) exists precisely so nothing forces the issue.
+#
+# The lower 5 GHz channels are no alternative: 36-48 are IR-CONCURRENT
+# (AP only alongside a client link on the same channel) and 52-140 are
+# DFS, which the supplicant's AP mode cannot do.
+#
 # Requires `"country":"BE"` in /mnt/boot/config.json. Without a country
 # the phy sits in regulatory domain 00, where AP mode cannot beacon.
 #

--- a/compose/compute/host/system-connections/ovcs0-ap.nmconnection.example
+++ b/compose/compute/host/system-connections/ovcs0-ap.nmconnection.example
@@ -1,14 +1,8 @@
 # The AX210 as an access point, bridged into the vehicle network.
 #
-# 2.4 GHz is not a preference, it is the only option this card offers
-# here. The AX210 is a self-managed regulatory phy; under BE its table
-# marks 5 GHz ch 36-48 IR-CONCURRENT (AP only alongside a client link
-# on the same channel) and ch 52-140 DFS (needs radar detection, which
-# NetworkManager's wpa_supplicant AP mode does not do). ch 149-173 the
-# card offers at 22 dBm, but the ETSI/BE regdb caps 5725-5875 at 13 dBm
-# and 5795-5815 is the road-tolling band — not somewhere to put a
-# transmitter on a vehicle. 2.4 GHz is clean and allows HT40 in
-# 2422-2462.
+# Channel 149 / 80 MHz requires the wifi_ap_fix service on NetworkManager
+# 1.52: it corrects the VHT center to 5775 MHz and limits TX power to
+# 6 dBm. Deploy that service before activating this profile.
 #
 # Requires `"country":"BE"` in /mnt/boot/config.json. Without a country
 # the phy sits in regulatory domain 00, where AP mode cannot beacon.
@@ -18,22 +12,20 @@
 # no such name (wlan0 or wlan1, depending on who registered first),
 # which is why uplink.nmconnection matches it by driver instead.
 #
-# channel: pick one clear of nearby APs — `nmcli device wifi list` on
-# the device shows what is around. NetworkManager 1.52 also exposes
-# 802-11-wireless.channel-width (auto yields HT20); HT40 needs ch 3-9
-# and roughly doubles throughput at the cost of spectrum.
-
 [connection]
 id=ovcs0-ap
 type=wifi
 interface-name=wlP1p1s0
 master=ovcs0
 slave-type=bridge
+autoconnect-priority=100
+autoconnect-retries=1
 
 [wifi]
 mode=ap
-band=bg
-channel=11
+band=a
+channel=149
+channel-width=80
 ssid=OVCS-Mini
 
 # proto/pairwise/group are not decoration. Left to itself

--- a/compose/compute/images/wifi-ap-fix/Dockerfile
+++ b/compose/compute/images/wifi-ap-fix/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-dbus iw \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY fix_ap.py /usr/local/bin/fix_ap.py
+CMD ["python3", "-u", "/usr/local/bin/fix_ap.py"]

--- a/compose/compute/images/wifi-ap-fix/fix_ap.py
+++ b/compose/compute/images/wifi-ap-fix/fix_ap.py
@@ -1,0 +1,115 @@
+"""Correct NetworkManager's channel-149 VHT center frequency on the AX210."""
+
+import logging
+import subprocess
+import time
+
+import dbus
+
+DEVICE = "wlP1p1s0"
+SUPPLICANT = "fi.w1.wpa_supplicant1"
+PROPERTIES = "org.freedesktop.DBus.Properties"
+NETWORK_MANAGER = "org.freedesktop.NetworkManager"
+LOG = logging.getLogger("wifi_ap_fix")
+
+
+def retry_preferred_profile(bus):
+    """Retry once if boot reached the fallback before this service started."""
+    manager = dbus.Interface(
+        bus.get_object(NETWORK_MANAGER, "/org/freedesktop/NetworkManager"), NETWORK_MANAGER,
+    )
+    device_path = manager.GetDeviceByIpIface(DEVICE)
+    device = bus.get_object(NETWORK_MANAGER, device_path)
+    active_path = dbus.Interface(device, PROPERTIES).Get(
+        f"{NETWORK_MANAGER}.Device", "ActiveConnection",
+    )
+    if active_path == "/":
+        return False
+    active = bus.get_object(NETWORK_MANAGER, active_path)
+    name = dbus.Interface(active, PROPERTIES).Get(
+        f"{NETWORK_MANAGER}.Connection.Active", "Id",
+    )
+    if name != "ovcs0-ap-fallback":
+        return False
+    settings = dbus.Interface(
+        bus.get_object(NETWORK_MANAGER, "/org/freedesktop/NetworkManager/Settings"),
+        f"{NETWORK_MANAGER}.Settings",
+    )
+    for path in settings.ListConnections():
+        connection = dbus.Interface(
+            bus.get_object(NETWORK_MANAGER, path), f"{NETWORK_MANAGER}.Settings.Connection",
+        )
+        values = connection.GetSettings()
+        if (
+            values["connection"]["id"] == "ovcs0-ap"
+            and values.get("802-11-wireless", {}).get("band") == "a"
+        ):
+            manager.ActivateConnection(path, device_path, dbus.ObjectPath("/"))
+            LOG.info("Retrying the preferred AP now that the correction service is ready")
+            return True
+    return False
+
+
+def correct_network(bus, path):
+    network = bus.get_object(SUPPLICANT, path)
+    properties = dbus.Interface(network, PROPERTIES)
+    values = properties.Get(f"{SUPPLICANT}.Network", "Properties")
+    # Supplicant exposes these network properties as strings. Only touch
+    # the invalid center generated for an AP on primary channel 149.
+    if not (
+        str(values.get("mode")) == "2"
+        and str(values.get("frequency")) == "5745"
+        and str(values.get("vht_center_freq1")) == "5770"
+    ):
+        return False
+    properties.Set(
+        f"{SUPPLICANT}.Network",
+        "Properties",
+        dbus.Dictionary({"vht_center_freq1": dbus.Int32(5775)}, signature="sv"),
+    )
+    return True
+
+
+def maintain(bus):
+    # Set the limit before enabling a corrected network. Repeat after a
+    # driver reset; the kernel still enforces its own regulatory limits.
+    info = subprocess.run(
+        ["iw", "dev", DEVICE, "info"], capture_output=True, text=True, check=False,
+    )
+    if info.returncode:
+        return
+    if "txpower 6.00 dBm" not in info.stdout:
+        subprocess.run(["iw", "dev", DEVICE, "set", "txpower", "limit", "600"], check=True)
+        LOG.info("Limited %s transmit power to 6 dBm", DEVICE)
+
+    root = dbus.Interface(bus.get_object(SUPPLICANT, "/fi/w1/wpa_supplicant1"), SUPPLICANT)
+    interface = bus.get_object(SUPPLICANT, root.GetInterface(DEVICE))
+    properties = dbus.Interface(interface, PROPERTIES)
+    for path in properties.Get(f"{SUPPLICANT}.Interface", "Networks"):
+        if correct_network(bus, path):
+            dbus.Interface(interface, f"{SUPPLICANT}.Interface").SelectNetwork(path)
+            LOG.info("Corrected channel 149 / 80 MHz center to 5775 MHz")
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+    last_error = None
+    retried = False
+    while True:
+        try:
+            bus = dbus.SystemBus()
+            maintain(bus)
+            if not retried:
+                retried = retry_preferred_profile(bus)
+            last_error = None
+        except (dbus.DBusException, subprocess.CalledProcessError) as error:
+            # Avoid printing network properties: they can contain credentials.
+            name = type(error).__name__
+            if name != last_error:
+                LOG.warning("Waiting for the AP interface (%s)", name)
+                last_error = name
+        time.sleep(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ros_compute_node.md
+++ b/docs/ros_compute_node.md
@@ -183,7 +183,7 @@ Two networks, each doing the one thing it is good at:
         │      MASQUERADE out via the uplink             │
         └────┬────────────────────────────┬──────────────┘
              │                            │
-          eth0                      wlP1p1s0  (AX210 AP "OVCS-Mini", 2.4 GHz)
+          eth0                      wlP1p1s0  (AX210 AP "OVCS-Mini", 5 GHz)
      vehicle switch:                a laptop with no site Wi-Fi,
      VMS, bridge-ros,               or one that wants the fabric
      bridge-ros_perception          at full rate
@@ -234,11 +234,13 @@ each file explain the rest:
   `NetworkManager.conf` lists `interface-name:br*` as unmanaged, so
   such a bridge is invisible to NetworkManager and activation fails
   with `device is strictly unmanaged`.
-- **The access point is 2.4 GHz because that is all the card offers.**
-  The AX210 is a self-managed regulatory phy; 5 GHz is either
-  `IR-CONCURRENT`, `DFS`, or in a band the ETSI regdb caps at 13 dBm
-  and partly allocates to road tolling. A 5 GHz AP here needs a
-  different card and hostapd, not a config change.
+- **The access point uses channel 149 at 80 MHz.** NetworkManager 1.52
+  generates an invalid VHT center frequency of 5770 MHz for this channel.
+  The `wifi_ap_fix` service corrects it to 5775 MHz through the host
+  supplicant's D-Bus interface and reapplies the tested 6 dBm TX limit.
+  Keep the configured regulatory country and account for antenna gain
+  when changing power. Deploy the service before installing the 5 GHz
+  profile; see the [host instructions](../compose/compute/host/README.md).
 
 ### Reaching the vehicle network from the site Wi-Fi
 

--- a/docs/ros_compute_node.md
+++ b/docs/ros_compute_node.md
@@ -504,7 +504,10 @@ one is open.
 compute node. The `wifi_firmware` service stages the blobs and iwlwifi
 binds them at boot ("loaded firmware version 89…", "loaded PNVM
 version…"); `"country": "BE"` reaches the AX210's self-managed phy;
-`OVCS-Mini` comes up unattended on ch 11 as `WPA2 WPA3`; `ovcs0` holds
+`OVCS-Mini` comes up unattended as `WPA2 WPA3` — on ch 11 before the
+5 GHz profile, on ch 149 / 80 MHz with `wifi_ap_fix` deployed, and the
+2.4 GHz clone `ovcs0-ap-fallback` takes over if 5 GHz cannot start;
+`ovcs0` holds
 `10.42.0.1/24` with `eth0` and the access point as its ports, and
 dnsmasq leases to the three Nerves boards by hostname. `uplink` on the
 onboard radio is the only default route. Every Nerves firmware is built
@@ -514,10 +517,9 @@ and both bridges peer with the router over the wire.
 
 What is left:
 
-1. Decide whether HT40 is worth it. `channel-width` is auto (HT20)
-   today; HT40 roughly doubles throughput for a laptop on the access
-   point but needs ch 3-9, which is where the site's other APs already
-   are.
+1. Confirm the 5 GHz access point survives a cold boot on the car,
+   including the fallback path (`ovcs0-ap-fallback` on ch 11 when
+   ch 149 does not come up).
 2. A reservation on the site router for the compute node's onboard radio, so
    the Foxglove URL stops moving.
 


### PR DESCRIPTION
The AX210 access point reverted to 2.4 GHz after reboot because its tested 5 GHz configuration was temporary. Persist channel 149 at 80 MHz and restore the required correction automatically at startup.

- Add a `wifi_ap_fix` service that corrects NetworkManager 1.52's invalid VHT center frequency from 5770 to 5775 MHz through the host supplicant's D-Bus interface. It reapplies the 6 dBm transmit-power limit and leaves already-correct network settings alone.
- Add a host configuration script that backs up the existing AP profile and writes preferred 5 GHz and lower-priority 2.4 GHz fallback profiles to both the active and boot configuration directories. If the fallback starts before the service, the service retries the preferred profile once.
- Update the AP template and deployment documentation to describe the persistent configuration and installation order.

Validation:
- Built and deployed the compute stack on OVCS Mini.
- Performed a real reboot and verified that the AP automatically returned on channel 149 (5745 MHz), width 80 MHz, center 5775 MHz, at 6 dBm.
- Confirmed that boot and active AP profiles match, the laptop reconnects in 80 MHz mode, Internet still uses the onboard Wi-Fi, and Foxglove reconnects with compression.
- `ruff check .`, shell syntax, Compose configuration and whitespace checks pass.

Deploy the service before running the host configuration script. `balena push` does not install host network profiles; the script must run on the balenaOS host. The service requires the host D-Bus socket, host networking and `NET_ADMIN`.


Follow-up commit: the status section of `docs/ros_compute_node.md` now describes the ch 149 / 80 MHz access point and its ch 11 fallback instead of the previous ch 11 setup; the AP keyfile carries the regulatory reason for the 6 dBm limit (the 80 MHz channel spans 5735-5815 MHz, capped at 13 dBm by the ETSI/BE table and overlapping the 5795-5815 road-tolling band); and the compose entry states that `wifi_ap_fix` edits the host supplicant's network behind NetworkManager, which is why it loops.
