### PR TITLE
fix(vms_core): let the planner's speed reach the ESC's edge of motion

### DIFF
--- a/compose/compute/nav2/config/nav2.yaml
+++ b/compose/compute/nav2/config/nav2.yaml
@@ -101,8 +101,17 @@ controller_server:
       batch_size: 1000
       vx_std: 0.2
       wz_std: 0.4
-      vx_max: 1.5
-      vx_min: -0.5
+      # Forward only, and no faster than the vehicle's speed at its
+      # throttle cap (`@max_speed_m_s` in the Mini's VMS composer):
+      # anything above saturates the actuator, and the optimizer would
+      # plan on a speed the truck cannot reach. Reverse is off because
+      # the Traxxas ESC treats the first pull into negative as braking
+      # and only reverses after a return to neutral, a sequence a
+      # velocity command cannot express; a reverse the controller
+      # believes in is a truck that does not move. The BackUp recovery
+      # is out of the behaviour trees for the same reason.
+      vx_max: 0.5
+      vx_min: 0.0
       wz_max: 2.5
       ax_max: 2.0
       ax_min: -2.0

--- a/compose/compute/nav2/config/nav2_ackermann_bt.xml
+++ b/compose/compute/nav2/config/nav2_ackermann_bt.xml
@@ -8,9 +8,12 @@
   the RecoveryNode burns a retry. With Spin first in the list, a single
   transient planning failure is enough to abort the whole action.
 
-  What remains is `Wait` (for a costmap that will clear on its own, e.g.
-  a moving obstacle) and `BackUp` (which a car genuinely can do, and
-  which is the useful recovery when it has nosed into a dead end).
+  `BackUp` is out too. The car could reverse, but its Traxxas ESC
+  treats the first pull into negative as braking and only reverses
+  after a return to neutral — a sequence a velocity command cannot
+  express — so the behaviour ran its full duration against a truck
+  that did not move, and burned a retry like Spin did. What remains is
+  `Wait`, for a costmap that will clear on its own (a moving obstacle).
 
   ClearCostmap services stay: they cost nothing and fix the common case
   of a stale obstacle.
@@ -37,7 +40,6 @@
         <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
         <!-- No Spin: this vehicle cannot execute one. -->
         <Wait wait_duration="2.0"/>
-        <BackUp backup_dist="0.30" backup_speed="0.15"/>
       </Sequence>
     </RecoveryNode>
   </BehaviorTree>

--- a/compose/compute/nav2/config/nav2_ackermann_through_poses_bt.xml
+++ b/compose/compute/nav2/config/nav2_ackermann_through_poses_bt.xml
@@ -8,11 +8,14 @@
 
   This is nav2_bt_navigator's stock
   `navigate_through_poses_w_replanning_and_recovery.xml` with exactly
-  one line removed: the `Spin` recovery. On an Ackermann vehicle a spin
-  command produces no motion — `AckermannSteering` needs forward speed
-  to generate any yaw — so the behaviour runs its full duration,
-  achieves nothing, and consumes a recovery slot. Since the recoveries
-  sit in a RoundRobin, Spin is tried every other failure.
+  two lines removed: the `Spin` and `BackUp` recoveries. On an Ackermann
+  vehicle a spin command produces no motion — `AckermannSteering` needs
+  forward speed to generate any yaw — and a backup command meets a
+  Traxxas ESC that treats the first pull into negative as braking and
+  only reverses after a return to neutral, which a velocity command
+  cannot express. Either behaviour runs its full duration, achieves
+  nothing, and consumes a recovery slot; in a RoundRobin that is every
+  other failure.
 
   Kept deliberately close to upstream so a Nav2 bump is a readable
   diff. The `spin` behaviour *server* is still loaded (see nav2.yaml) —
@@ -70,7 +73,6 @@
               <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
             </Sequence>
             <Wait name="WaitRecovery" wait_duration="5.0" error_code_id="{wait_error_code}" error_msg="{wait_error_msg}"/>
-            <BackUp name="BackUpRecovery" backup_dist="0.30" backup_speed="0.15" error_code_id="{backup_error_code}" error_msg="{backup_error_msg}"/>
           </RoundRobin>
         </ReactiveFallback>
       </Sequence>

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -35,13 +35,15 @@ defmodule OvcsMini.Vms.Composer do
   # Throttle feel, see `Traxxas.Throttle` for what each one does.
   @throttle_deadzone Decimal.new("0.05")
   @throttle_expo Decimal.new("0.5")
-  # MEASURED: with the ESC calibrated against this actuator's full
-  # range, the wheels first turned at an output of 0.057 (1528 µs), so
-  # the edge of motion sits at 0.05. Below it the pulse is wasted;
-  # above it, with the 0.1 cap, 25 µs of travel remain to modulate
-  # speed, which is what this vehicle has to offer at these speeds. The
-  # planner's requests land on the same band (see `Traxxas.Throttle`).
-  @throttle_start_offset Decimal.new("0.05")
+  # MEASURED on the ground, with the ESC calibrated against this
+  # actuator's full range: an output of 0.057 (1528 µs) did not move
+  # the truck, 0.070 (1535 µs) did not either, 0.085 (1543 µs) did. The
+  # edge of motion under load is about 0.075; below it the pulse is
+  # wasted. With the 0.1 cap that leaves 12 µs to modulate speed, which
+  # is what this ESC offers at these speeds — the planner's requests
+  # land on the same band (see `Traxxas.Throttle`), and the ESC's
+  # training profile is the way to widen it without going faster.
+  @throttle_start_offset Decimal.new("0.075")
   # A tenth of the pulse range forward (1550 µs at full trigger), with
   # the ESC calibrated against this actuator's full 1000-2000 µs range.
   # Half the range was far too fast for where the truck drives and a

--- a/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
+++ b/vehicles/ovcs_mini/lib/ovcs_mini/vms/composer.ex
@@ -35,11 +35,13 @@ defmodule OvcsMini.Vms.Composer do
   # Throttle feel, see `Traxxas.Throttle` for what each one does.
   @throttle_deadzone Decimal.new("0.05")
   @throttle_expo Decimal.new("0.5")
-  # A 10 us start offset leaves 40 us of forward modulation before the
-  # 1550 us cap. Keep this conservative until the ESC's start/stop
-  # thresholds have been measured under load; the Radio Control page
-  # exposes the commanded pulse width, before HAT timer quantisation.
-  @throttle_start_offset Decimal.new("0.02")
+  # MEASURED: with the ESC calibrated against this actuator's full
+  # range, the wheels first turned at an output of 0.057 (1528 µs), so
+  # the edge of motion sits at 0.05. Below it the pulse is wasted;
+  # above it, with the 0.1 cap, 25 µs of travel remain to modulate
+  # speed, which is what this vehicle has to offer at these speeds. The
+  # planner's requests land on the same band (see `Traxxas.Throttle`).
+  @throttle_start_offset Decimal.new("0.05")
   # A tenth of the pulse range forward (1550 µs at full trigger), with
   # the ESC calibrated against this actuator's full 1000-2000 µs range.
   # Half the range was far too fast for where the truck drives and a

--- a/vms/core/lib/vms_core/components/traxxas/throttle.ex
+++ b/vms/core/lib/vms_core/components/traxxas/throttle.ex
@@ -31,14 +31,25 @@ defmodule VmsCore.Components.Traxxas.Throttle do
      *output* at which the wheels first move -- the value written to
      the ESC, not the request shown on the dashboard.
 
-  All three are properties of a *hand* on an axis, not of the actuator.
-  A commander that sends a physical quantity -- `RosVelocityCommand`
-  normalises metres per second -- expects its request applied as is, or
-  a planner asking for a fifth of full speed gets a twenty-fifth, and a
-  planner decelerating through a tiny velocity expects the vehicle to
-  follow it down rather than hold the edge of motion. `:linear_sources`
-  lists the sources whose request is already a physical quantity: they
-  skip all three steps.
+  The dead zone and the feel curve are properties of a *hand* on an
+  axis, not of the actuator. A commander that sends a physical quantity
+  -- `RosVelocityCommand` normalises metres per second -- expects its
+  request applied proportionally, or a planner asking for a fifth of
+  full speed gets a twenty-fifth. `:linear_sources` lists the sources
+  whose request is already a physical quantity: they skip those two
+  steps.
+
+  The start offset is different: it is a property of the *ESC*, which
+  does not turn the motor below a minimum pulse whoever is asking. A
+  linear request therefore lands on `[start_offset, cap]` like a hand's
+  does, so any speed a planner commands reaches the edge of motion
+  instead of being silently wasted below it -- with a cap of a tenth of
+  the pulse range, a proportional request of 0.3 would otherwise sit
+  15 µs above neutral and move nothing, and the planner, seeing no
+  progress, would fall back on its recoveries. Requests below a small
+  epsilon (2 % of full travel) are zero, so a planner decelerating
+  through tiny velocities comes to rest rather than holding the edge of
+  motion.
 
   ## The cap
 
@@ -69,6 +80,12 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   @pwm_period_us D.new(div(1_000_000, @pwm_frequency))
   @zero D.new(0)
   @one D.new(1)
+
+  # Below this a physical request is a stop, not a speed: with the start
+  # offset applied to linear sources too, something has to separate "hold
+  # the edge of motion" from "come to rest", and a planner's decelerating
+  # trail of tiny velocities is the latter.
+  @linear_epsilon D.new("0.02")
 
   @default_curve %{
     deadzone: @zero,
@@ -239,12 +256,18 @@ defmodule VmsCore.Components.Traxxas.Throttle do
   end
 
   @doc """
-  The output in [-1, 1] for a request in [-1, 1]. A linear request is
-  only scaled by the cap; a shaped one goes through all three steps and
-  lands on `[start_offset, cap]`.
+  The output in [-1, 1] for a request in [-1, 1]. A shaped request goes
+  through all three steps; a linear one skips the dead zone and the feel
+  curve. Both land on `[start_offset, cap]`, and both are zero at rest.
   """
   def shape(requested, true = _linear, curve) do
-    requested |> D.abs() |> D.min(@one) |> D.mult(cap(requested, curve)) |> signed_as(requested)
+    magnitude = requested |> D.abs() |> D.min(@one)
+
+    if D.lt?(magnitude, @linear_epsilon) do
+      @zero
+    else
+      offset(signed_as(magnitude, requested), curve.start_offset, cap(requested, curve))
+    end
   end
 
   def shape(requested, false, curve) do

--- a/vms/core/test/components/traxxas/source_switching_test.exs
+++ b/vms/core/test/components/traxxas/source_switching_test.exs
@@ -236,12 +236,35 @@ defmodule VmsCore.Components.Traxxas.SourceSwitchingTest do
       assert D.eq?(Throttle.shape(D.new("1"), false, curve), D.new("1"))
     end
 
-    test "a physical quantity is applied as is" do
+    test "a physical quantity skips the dead zone and the feel curve" do
       # A planner asking for a fifth of full speed must get a fifth,
       # not a twenty-fifth.
       curve = Throttle.curve(%{})
       assert D.eq?(Throttle.shape(D.new("0.2"), true, curve), D.new("0.2"))
       assert D.eq?(Throttle.shape(D.new("-0.2"), true, curve), D.new("-0.2"))
+    end
+
+    test "a physical quantity still lands on [start_offset, cap]" do
+      # The ESC does not move below its minimum pulse whoever asks, so a
+      # planner's request is stretched over the band that does move:
+      # 0.05 + 0.3 × (0.1 − 0.05) = 0.065, not 0.3 × 0.1 = 0.03.
+      curve =
+        Throttle.curve(%{
+          start_offset: D.new("0.05"),
+          max_throttle: D.new("0.1"),
+          max_reverse: D.new("0.2")
+        })
+
+      assert D.eq?(Throttle.shape(D.new("0.3"), true, curve), D.new("0.065"))
+      assert D.eq?(Throttle.shape(D.new("1"), true, curve), D.new("0.1"))
+      assert D.eq?(Throttle.shape(D.new("-0.3"), true, curve), D.new("-0.095"))
+    end
+
+    test "a physical quantity below the epsilon is a stop, not the edge of motion" do
+      curve = Throttle.curve(%{start_offset: D.new("0.05"), max_throttle: D.new("0.1")})
+      assert D.eq?(Throttle.shape(D.new("0.01"), true, curve), D.new(0))
+      assert D.eq?(Throttle.shape(D.new("-0.019"), true, curve), D.new(0))
+      assert D.eq?(Throttle.shape(D.new("0.02"), true, curve), D.new("0.051"))
     end
 
     test "expo blends between linear and square" do
@@ -288,16 +311,20 @@ defmodule VmsCore.Components.Traxxas.SourceSwitchingTest do
       assert D.eq?(Throttle.shape(D.new("0.525"), false, curve), D.new("0.55"))
     end
 
-    test "a physical quantity skips the dead zone, the curve and the start offset" do
-      # A planner decelerating through a tiny velocity must be followed
-      # down, not held at the edge of motion until it publishes exactly
-      # zero.
+    test "a physical quantity skips the dead zone and the curve but not the offset" do
+      # The dead zone and the curve are a hand's; the offset is the
+      # ESC's. A planner's request is proportional above the epsilon and
+      # lands on [start_offset, cap], so any speed it asks for moves the
+      # vehicle; below the epsilon it is a stop, so a planner
+      # decelerating through tiny velocities comes to rest.
       curve =
         Throttle.curve(%{deadzone: D.new("0.05"), expo: D.new(1), start_offset: D.new("0.1")})
 
       assert D.eq?(Throttle.shape(D.new(0), true, curve), D.new(0))
-      assert D.eq?(Throttle.shape(D.new("0.02"), true, curve), D.new("0.02"))
-      assert D.eq?(Throttle.shape(D.new("-0.5"), true, curve), D.new("-0.5"))
+      assert D.eq?(Throttle.shape(D.new("0.01"), true, curve), D.new(0))
+      # 0.1 + 0.02 × 0.9: no dead zone, no squaring, the offset applied.
+      assert D.eq?(Throttle.shape(D.new("0.02"), true, curve), D.new("0.118"))
+      assert D.eq?(Throttle.shape(D.new("-0.5"), true, curve), D.new("-0.55"))
       assert D.eq?(Throttle.shape(D.new("1"), true, curve), D.new("1"))
     end
 


### PR DESCRIPTION
## Symptom

A Nav2 goal on the Mini in `:ros` / `:autonomous`: the VMS receives and applies the planner's velocity, the ESC pulse changes, the truck does not move. Sampled on the car: Nav2 asked -0.30 to -0.36 (its BackUp recovery, 0.15 m/s in reverse) for 40 s; the actuator output -0.06 to -0.072 (1465 µs); speed stayed 0. Taking the radio at the same moment, the truck started moving at an output of 0.057 (1528 µs).

## Two causes

1. **The planner's request never reached the edge of motion.** `Traxxas.Throttle` applied the start offset to hand sources only; a linear (physical) source was request × cap. With the Mini's cap at 0.1, a request of 0.3 is 0.03 (1515 µs) — below the pulse the ESC moves at. Nav2 never asks for more than a fraction of `vx_max`, so it never moved the truck, saw no progress, and went into recovery.
2. **The recovery was BackUp**, and this ESC treats the first pull into negative as braking; reverse needs a return to neutral first, which a velocity stream cannot express. So the recovery burned its duration against a truck that did not move, exactly as Spin did before it was removed.

## Changes

- `Traxxas.Throttle`: linear sources skip the dead zone and the feel curve as before, but now land on `[start_offset, cap]`; below an epsilon of 2 % of travel the request is a stop, so a decelerating planner comes to rest. Tests updated and added (23 pass).
- Mini composer: `start_offset` 0.02 → **0.05**, the measured edge of motion (0.057 with the ESC calibrated against the actuator's full 1000-2000 µs range).
- `nav2.yaml`: MPPI `vx_min` -0.5 → 0.0 (forward only), `vx_max` 1.5 → 0.5 (the speed at the throttle cap, `@max_speed_m_s`).
- Both behaviour trees: `BackUp` recovery removed, comments updated (XML validated).

## Verified

`mix test --no-start test/components/traxxas`: 23 tests, 0 failures. VMS firmware builds. Not yet driven under Nav2 — that is the next test.